### PR TITLE
fix error in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Installation
 4.  Build a version of PostgreSQL:
 
     ~~~ sh
-    $ pgenv install 10.4
+    $ pgenv build 10.4
     ~~~
 
 ### Upgrading


### PR DESCRIPTION
the example says to install 10.4, but you need to build 10.4