### PR TITLE
Fix pgenv root

### DIFF
--- a/bin/pgenv
+++ b/bin/pgenv
@@ -20,6 +20,10 @@
 set -e
 
 PGENV_ROOT=$(dirname $(dirname $0))
+cd $PGENV_ROOT
+# use always an absolute path or configure could complain
+PGENV_ROOT=$(pwd)
+
 PGSQL=$PGENV_ROOT/pgsql
 PG_DATA=$PGSQL/data
 
@@ -27,9 +31,6 @@ PG_DATA=$PGSQL/data
 PG_CTL="$PGSQL/bin/pg_ctl -D $PG_DATA"
 INITDB="$PGSQL/bin/initdb -U postgres --locale en_US.UTF-8 --encoding UNICODE -D $PG_DATA"
 
-cd $PGENV_ROOT
-# use always an absolute path or configure could complain
-PGENV_ROOT=$(pwd)
 
 pgversions() {
     if [ -e "pgsql" ]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -28,6 +28,8 @@ PG_CTL="$PGSQL/bin/pg_ctl -D $PG_DATA"
 INITDB="$PGSQL/bin/initdb -U postgres --locale en_US.UTF-8 --encoding UNICODE -D $PG_DATA"
 
 cd $PGENV_ROOT
+# use always an absolute path or configure could complain
+PGENV_ROOT=$(pwd)
 
 pgversions() {
     if [ -e "pgsql" ]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -19,7 +19,13 @@
 # https://stackoverflow.com/a/19622569/79202
 set -e
 
-PGENV_ROOT=$(dirname $(dirname $0))
+# set PGENV_ROOT only if not already set
+if [ -z "$PGENV_ROOT" ]; then
+    PGENV_ROOT=$(dirname $(dirname $0))
+else
+    echo "Using external PGENV_ROOT environment variable [$PGENV_ROOT]"
+fi
+
 cd $PGENV_ROOT
 # use always an absolute path or configure could complain
 PGENV_ROOT=$(pwd)
@@ -60,6 +66,10 @@ The pgenv commands are:
     version   Show the current PostgreSQL version
     versions  List all PostgreSQL versions available to pgenv
     help      Show this usage statement and command summary
+
+It is possible to specify the directory where PostgreSQL clusters
+will be installed via PGENV_ROOT environment variable, otherwise
+the script directory will be used.
 
 For full documentation, see: https://github.com/theory/pgenv#readme
 EOF


### PR DESCRIPTION
PGENV_ROOT should always be an absolute path, or some tools like configure could complain. To fix this, even when pggenv is invoked with a relative path, a `pwd` is used to get the absolute path.