### PR TITLE
Auto select pl languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ project directory (generally, in `~/.pgenv`.). If you'd like them to live
 elsewhere, set the `$PGENV_ROOT` environment variable to the appropriate
 value.
 
+Each instance will be compiled with support for PL/Perl and/or PL/Python
+depending on the existance of interpreters. It is possible to compile
+an instance with a particular interpreter or without PL/Perl or PL/Python
+setting variables before the build process is started. See the section
+about `build`.
+
 ### Upgrading
 
 You can upgrade your installation to the cutting-edge version at any time
@@ -172,6 +178,21 @@ The build will install PL/Perl and/or PL/Python depending on the current environ
 if Perl and/or Python interpreters are available, the `configure` part of the build
 process will reflect their presence and will build interpreters into the
 PostgreSQL instance.
+It is possible tro drive the PL/Perl and PL/Python `configure` process settings
+the special variables `PGENV_PERL` and `PGENV_PYTHON` to the location of the
+desired interpreter. In particular, the behavior for both variables is as follows:
+- if the variable is not set or set to an empty string, the system will try to
+  figure out if an interpreter exists within the user's `PATH` and will use such
+  interpreter to build the PL-language;
+- if the variable is set to an executable interpreter, the language will be built
+  using such interpreter
+- if the variable is set to a non-executable value, the language will not be built.
+
+As an example, the following will build an instance without PL/Perl and
+with a specific version of Python:
+
+    $ PGENV_PERL=no PGENV_PYTHON=/usr/python/2.7/bin/python pgenv build 10.5
+
 
 ### pgenv remove
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ $ git pull
 *   sed, grep, cat, tar - General Unix command line utilities
 *   patch - For patching versions that need patching
 *   make -  Builds PostgreSQL
-*   Perl 5 - To build PL/Perl
+*   Perl 5 - To build PL/Perl (not mandatory)
+*   Python - To build PL/Python (not mandatory)
 
 Command Reference
 -----------------
@@ -166,6 +167,11 @@ before building. If the version is already built, it will not be rebuilt; use
     $ pgenv build 10.3
     # Curl, configure, and make output elided
     PostgreSQL 10.3 built
+
+The build will install PL/Perl and/or PL/Python depending on the current environment:
+if Perl and/or Python interpreters are available, the `configure` part of the build
+process will reflect their presence and will build interpreters into the
+PostgreSQL instance.
 
 ### pgenv remove
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -397,8 +397,9 @@ case $1 in
 EOF
         fi
 
-        # Configure.
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v --with-perl PERL=$PGENV_PERL
+        # Configure: use the variable PGENV_CONFIGURE_PL for PL/Perl and PL/Python languages
+        # that has been auto-computed by pgenv_check_dependencies
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -89,16 +89,34 @@ pgenv_check_dependencies(){
 
     local present=""
     local missing=""
+    local warning=""
 
     pgenv_detail_command(){
         local command_name=$1
         local command=$2
+        local language=$3
+
         local nl=$'\n'
         local tab=$'\t'
         if [ -z "$command" ]; then
-            missing+="[KO] $command_name:${tab}NOT found!$nl"
+            if [ -z "$language" ]; then
+                missing+="[KO] $command_name:${tab}NOT found!$nl"
+            else
+                warning+="[KO] $command_name:${tab}NOT found (cannot build $language)$nl"
+            fi
         else
             present+="[OK] $command_name:$tab$command$nl"
+        fi
+    }
+
+    # Appends a language interpreter configuration
+    # to the 'configure' variable used to build the system
+    pgenv_configure_pl(){
+        local language=$1
+        local interpreter=$2
+
+        if [ ! -z "$interpreter" ]; then
+            PGENV_CONFIGURE_PL+="--with-${language}  $( echo $language | tr 'a-z' 'A-Z' )=${interpreter} "
         fi
     }
 
@@ -121,13 +139,21 @@ pgenv_check_dependencies(){
     pgenv_detail_command "sed" $PGENV_SED
 
     PGENV_PERL=$(which perl)
-    pgenv_detail_command "perl" $PGENV_PERL
+    pgenv_detail_command "perl" "$PGENV_PERL" "PL/Perl"
+    pgenv_configure_pl "perl" $PGENV_PERL
+
+    PGENV_PYTHON=$(which python)
+    pgenv_detail_command "python" "$PGENV_PYTHON" "PL/Python"
+    pgenv_configure_pl "python" $PGENV_PYTHON
 
 
     # Go back to exiting on error.
     trap 'exit' ERR
     if [ ! -z "$verbose" ]; then
         echo -n "$present"
+    fi
+    if [ ! -z "$verbose" ]; then
+        echo -n "$warning"
     fi
     if [ ! -z "$missing" ]; then
         echo "$missing"

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -138,11 +138,23 @@ pgenv_check_dependencies(){
     PGENV_SED=$(which sed)
     pgenv_detail_command "sed" $PGENV_SED
 
-    PGENV_PERL=$(which perl)
+    # if PGENV_PERL has been set from outside
+    # of the script and points to an executable
+    # use that, otherwise try to figure it out
+    if [ -z "$PGENV_PERL" ]; then
+        PGENV_PERL=$(which perl)
+    elif [ ! -x "$PGENV_PERL" ]; then
+        PGENV_PERL=""
+    fi
     pgenv_detail_command "perl" "$PGENV_PERL" "PL/Perl"
     pgenv_configure_pl "perl" $PGENV_PERL
 
-    PGENV_PYTHON=$(which python)
+    # same reason for python
+    if [ -z "$PGENV_PYTHON" ]; then
+        PGENV_PYTHON=$(which python)
+    elif [ ! -x "$PGENV_PYTHON" ]; then
+        PGENV_PYTHON=""
+    fi
     pgenv_detail_command "python" "$PGENV_PYTHON" "PL/Python"
     pgenv_configure_pl "python" $PGENV_PYTHON
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -151,8 +151,6 @@ pgenv_check_dependencies(){
     trap 'exit' ERR
     if [ ! -z "$verbose" ]; then
         echo -n "$present"
-    fi
-    if [ ! -z "$verbose" ]; then
         echo -n "$warning"
     fi
     if [ ! -z "$missing" ]; then


### PR DESCRIPTION
I request a review about this couple of commits: the idea is to "remove" automatically Perl dependency and, in the meantime, add a depedency on Python. Ok, this sounds weird but:
1) interpreters (Perl, Python) should not be mandatory dependencies;
2) if one or both are found when checking for dependencies, the build process will build both of them as PLs
3) if any of them is missing, the build process will not fail anymore.

I'm not sure this is the default behavior we want, but at least it makes the program more autonomous.