### PR TITLE
Configuration management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /pgsql*
 /src/
+/.pgenv.*

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ version. Use the `clear` command to clear the active version before removing it.
     $ pgenv remove 10.3
     PostgreSQL 10.3 removed
 
+The command removes the instance, data directory, source code and configuration.
+
 ### pgenv start
 
 Starts the currently active version of PostgreSQL if it's not already running.
@@ -375,28 +377,46 @@ In order to start with a default configuration, use the `write` subcommand:
     
 so that a `show` will give you back the defaults:
  
-   $ pgenv config show
-   ###############################
-   #
-   #
-   # PostgreSQL 
+   $ pgenv config show default
+   # Default configuration
    # pgenv configuration for PostgreSQL 
-   # File: ~/.pgenv/.pgenv.conf 
-   # Dumped on:  lun 10 set 2018, 10.56.01, CEST
-   #
-   # 8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-
+   # File: /home/luca/git/misc/PostgreSQL/pgenv/.pgenv.conf
+   # ---------------------------------------------------
+   # pgenv configuration created on mer 12 set 2018, 08.35.52, CEST
+
    # Enables debug output
-   # PGENV_DEBUG=
+   # PGENV_DEBUG=''
 
-   # Cluster stop mode for 'stop' and 'restart'
-   # PGENV_STOP_MODE=
-   
-   # <output omitted>
+   ###### Build settings #####
+   # Make command to use for build
+   # PGENV_MAKE=''
 
-   # ->8->8->8->8->8->8->8->8->8->8->8->8
-   #
-   # End of configuration
-   ###############################
+   # Make flags
+   PGENV_MAKE_OPTS='-j3'
+
+   # Configure flags
+   # PGENV_CONFIGURE_OPTS=''
+
+   # Perl 5 executable to build PL/Perl
+   # PGENV_PLPERL=''
+
+   # Python executable to build PL/Perl
+   # PGENV_PLPYTHON=''
+
+   # ...
+
+   ##### Runtime options #####
+   # Path to the cluster log file
+   PGENV_LOG='/home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log'
+
+   # Cluster administrator user
+   PGENV_PG_USER='postgres'
+
+   # Initdb flags
+   PGENV_INITDB_OPTS='-U postgres --locale en_US.UTF-8 --encoding UNICODE'
+
+   # ...
+
 
 You can edit the file and adjust parameters to your needs.
 
@@ -427,6 +447,9 @@ loose your configuration:
    Cannot delete default configuration while instances installed
    You need to manually remove [~/.pgenv/.pgenv.conf]
 
+Please note that when a configuration file is removed, also its backup copy is deleted.
+When an instance is removed by means of `pgenv remove`, also its configuration (if any) is
+removed.
 
 # Bug Reporting
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Each version will be compiled with support for PL/Perl and PL/Python when
 `pgenv` can find their interpreters or using the value of the `$PGENV_PERL` and
 `$PGENV_PYTHON` variables. See [`pgenv build`](#pgenv-build) below for details.
 
+For a more detailed configuration, see the [`pgenv config`](#pgenv-config) command
+below.
+
 ### Upgrading
 
 You can upgrade your installation to the cutting-edge version at any time

--- a/README.md
+++ b/README.md
@@ -159,7 +159,12 @@ Each version is installed in a `pgsql-` subdirectory of `$PGENV_ROOT`.
 Displays the currently active PostgreSQL version.
 
     $ pgenv version
-    pgsql-10.4
+    10.4
+    
+Please note that `current` is a command synonim for version:
+
+    $ pgenv current
+    10.4
 
 ### pgenv clear
 
@@ -200,6 +205,9 @@ For example, the following will build an instance without PL/Perl and
 with a specific version of Python:
 
     $ PGENV_PERL=no PGENV_PYTHON=/usr/python/2.7/bin/python pgenv build 10.5
+    
+You can also set the `PGENV_PERL` and `PGENV_PYTHON` variables in the configuration
+file (see [pgenv config](#pgenv-config)).
 
 ### pgenv remove
 
@@ -267,7 +275,8 @@ already running.
     Logging to pgsql/data/server.log
 
 It is possible to provide the stop mode similarly to the `stop`, by either
-passing it as command line argument or via `PGENV_STOP_MODE` variable:
+passing it as command line argument or via `PGENV_STOP_MODE` variable 
+(either in the command line or in the configuration file):
 
     $ pgenv restart immediate
     $ PGENV_STOP_MODE="immediate" pgenv restart

--- a/README.md
+++ b/README.md
@@ -403,7 +403,10 @@ to the `write` subcommand:
    $ pgenv config write 10.5
    pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
 
-and you can use the `edit` subcommand to fire up your favourite editor:
+Each time a configuration file is written, a backup copy with the suffix `.backup` is created
+to retain the very last copy before the last write.
+
+You can use the `edit` subcommand to fire up your favourite editor:
 
    $ pgenv config edit 10.5
    <output omitted>

--- a/README.md
+++ b/README.md
@@ -336,8 +336,91 @@ the following:
         help       Show this usage statement and command summary
         available  Show which versions can be downloaded (most recent versions last)
         check      Check all program dependencies
+        config     View, edit, delete the program configuration
 
     For full documentation, see: https://github.com/theory/pgenv#readme
+
+### pgenv config
+
+The `config` command allows the user to see and/or manipulate the configuration.
+`pgenv` handles configuration on a per-version basis: each PostgreSQL instance can have
+its own configuration set, which is contained in a Bash file that contains variables
+definition. It is possible to store also a *default* configuration, that is applied
+if no specific per-version configuration is found.
+If neither the per-version nor the default configuration is found, the program tries
+to guess its own configuration whenever possible, applying defaults in many cases.
+
+The `config` command accepts the following subcommands:
+- `show` prints the current configuration, or the specific version one;
+- `write` stores the current configuration or the specific version one;
+- `edit` fires your favourite editor (using `$EDITOR`);
+- `delete` removes the specific configuration.
+
+Every sub-command accepts a PostgreSQL version number (e.g., `10.5`), and special
+keywords can be used:
+- `current` or `version` to let the program automatically "compute" the version number
+  for the PostgreSQL currently in use;
+- `default` operates on the default configuration.
+
+If no version is explicitly passed to any of the `config` subcommands, the program will
+work against the currently in use PostgreSQL instance.
+
+In order to start with a default configuration, use the `write` subcommand:
+
+    $ pgenv config write default
+    pgenv configuration file [~/.pgenv/.pgenv.conf] written
+    
+so that a `show` will give you back the defaults:
+ 
+   $ pgenv config show
+   ###############################
+   #
+   #
+   # PostgreSQL 
+   # pgenv configuration for PostgreSQL 
+   # File: ~/.pgenv/.pgenv.conf 
+   # Dumped on:  lun 10 set 2018, 10.56.01, CEST
+   #
+   # 8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-
+   # Enables debug output
+   # PGENV_DEBUG=
+
+   # Cluster stop mode for 'stop' and 'restart'
+   # PGENV_STOP_MODE=
+   
+   # <output omitted>
+
+   # ->8->8->8->8->8->8->8->8->8->8->8->8
+   #
+   # End of configuration
+   ###############################
+
+You can edit the file and adjust parameters to your needs.
+
+In order to create a configuration file from scratch for a specific version, specify it
+to the `write` subcommand:
+
+   $ pgenv config write 10.5
+   pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
+
+and you can use the `edit` subcommand to fire up your favourite editor:
+
+   $ pgenv config edit 10.5
+   <output omitted>
+
+To delete a configuration, use the `delete` subcommand:
+
+   $ pgenv config delete 10.5
+   Configuration file [~/.pgenv/.pgenv.10.5.conf] deleted
+
+It is worth noting that you cannot delete the default configuration unless all instances
+have been removed (e.g., by `pgenv remove`). This is made to prevent you to accidentally
+loose your configuration:
+
+   $ pgenv config delete
+   Cannot delete default configuration while instances installed
+   You need to manually remove [~/.pgenv/.pgenv.conf]
+
 
 # Bug Reporting
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -29,6 +29,7 @@ INITDB="$PGSQL/bin/initdb "
 PGENV_LOG=$PG_DATA/server.log
 PGENV_PG_USER="postgres"
 PGENV_FLAGS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
+PGENV_FLAGS_MAKE="-j3"
 #############################################
 
 # Prints a debug message if PGENV_DEBUG
@@ -440,6 +441,7 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" "Path to the cluster log file"
     pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
     pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_INITDB" "$PGENV_FLAGS_INITDB" "Initdb flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_MAKE" "$PGENV_FLAGS_MAKE" "Make flags"
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPERL" "$PGENV_PLPERL" 'Perl 5 executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLpython" 'Python executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
@@ -675,14 +677,14 @@ EOF
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then
             # 8.x (and prior versions?) doesn't have `make world`.
-            $PGENV_MAKE -j3
+            $PGENV_MAKE "$PGENV_FLAGS_MAKE
             $PGENV_MAKE install
             cd contrib
-            $PGENV_MAKE -j3
+            $PGENV_MAKE "$PGENV_FLAGS_MAKE
             $PGENV_MAKE install
         else
             # Yay, make world!
-            $PGENV_MAKE world -j3
+            $PGENV_MAKE world "$PGENV_FLAGS_MAKE
             $PGENV_MAKE install-world
         fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -493,7 +493,9 @@ pgenv_start_instance(){
 pgenv_initdb(){
     if [ ! -d $PG_DATA ]; then
         pgenv_debug "initdb running with flags [$PGENV_FLAGS_INITDB]"
-        $INITDB "$PGENV_FLAGS_INITDB" -D "$PG_DATA"
+        $INITDB -D "$PG_DATA" "$PGENV_FLAGS_INITDB"
+    else
+        pgenv_debug "Directory $PG_DATA exists, not initdb-ing!"
     fi
 }
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -30,6 +30,7 @@ PGENV_LOG=$PG_DATA/server.log
 PGENV_PG_USER="postgres"
 PGENV_FLAGS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
 PGENV_FLAGS_MAKE="-j3"
+PGENV_FLAGS_CONFIGURE=""
 #############################################
 
 # Prints a debug message if PGENV_DEBUG
@@ -442,6 +443,7 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
     pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_INITDB" "$PGENV_FLAGS_INITDB" "Initdb flags"
     pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_MAKE" "$PGENV_FLAGS_MAKE" "Make flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_CONFIGURE" "$PGENV_FLAGS_CONFIGURE" "Configure flags"
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPERL" "$PGENV_PLPERL" 'Perl 5 executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLpython" 'Python executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
@@ -450,7 +452,7 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
 
 
-    echo "pgenv configuration file [$CONF] written"
+    echo "pgenv configuration written to file [$CONF]"
 }
 
 
@@ -672,19 +674,19 @@ EOF
 
         # Configure: use the variable PGENV_CONFIGURE_PL for PL/Perl and PL/Python languages
         # that have been auto-computed by pgenv_check_dependencies
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_FLAGS_CONFIGURE"
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then
             # 8.x (and prior versions?) doesn't have `make world`.
-            $PGENV_MAKE "$PGENV_FLAGS_MAKE
+            $PGENV_MAKE "$PGENV_FLAGS_MAKE"
             $PGENV_MAKE install
             cd contrib
-            $PGENV_MAKE "$PGENV_FLAGS_MAKE
+            $PGENV_MAKE "$PGENV_FLAGS_MAKE"
             $PGENV_MAKE install
         else
             # Yay, make world!
-            $PGENV_MAKE world "$PGENV_FLAGS_MAKE
+            $PGENV_MAKE world "$PGENV_FLAGS_MAKE"
             $PGENV_MAKE install-world
         fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -686,6 +686,10 @@ EOF
             $PGENV_MAKE install-world
         fi
 
+
+        # write the configuration
+        pgenv_configuration_write "$v"
+
         echo "PostgreSQL $v built"
         exit
         ;;

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -739,7 +739,7 @@ EOF
         exit
         ;;
 
-    version)
+    version|current)
         pgenv_current_postgresql_or_exit
         pgenv_current_version_number
         exit

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -17,13 +17,19 @@ PGENV_ROOT=$(pwd)
 
 PGSQL=$PGENV_ROOT/pgsql
 PG_DATA=$PGSQL/data
-PG_LOG=$PG_DATA/server.log
 PGENV_DOWNLOAD_ROOT='https://ftp.postgresql.org/pub/source/'
 
 # Now -w because 9.0 and earlier always time out even when successful.
-PG_CTL="$PGSQL/bin/pg_ctl -D $PG_DATA"
+PG_CTL="$PGSQL/bin/pg_ctl "
+INITDB="$PGSQL/bin/initdb "
+
+#############################################
+# Configuration variable and default settings
+
+PGENV_LOG=$PG_DATA/server.log
 PGENV_PG_USER="postgres"
-INITDB="$PGSQL/bin/initdb -U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE -D $PG_DATA"
+PGENV_FLAGS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
+#############################################
 
 # Prints a debug message if PGENV_DEBUG
 # variable enabled
@@ -73,6 +79,7 @@ The pgenv commands are:
     help       Show this usage statement and command summary
     available  Show which versions can be downloaded (most recent versions last)
     check      Check all program dependencies
+    config     View, edit, delete the program configuration
 
 For full documentation, see: https://github.com/theory/pgenv#readme
 EOF
@@ -260,6 +267,49 @@ pgenv_current_version_number(){
     echo $v
 }
 
+# Provides the configuration file name
+# for the specified version.
+#
+# If no version is specified, the default configuration
+# file is provided.
+pgenv_configuration_file_name(){
+    local v=$1
+
+    PGENV_DEFAULT_CONFIG_FILE="${PGENV_ROOT}/.pgenv.conf"
+    if [ ! -z "$v" ]; then
+        echo "${PGENV_ROOT}/.pgenv.$v.conf"
+    else
+        echo "${PGENV_DEFAULT_CONFIG_FILE}"
+    fi
+}
+
+# Dumps the specified configuration file (if exists) or aborts.
+#
+# The function accept two option arguments:
+# - the version number (if not specified the default configuration will be considered)
+# - a title to use for printing the configruation file
+#
+# If the file cannot be found the function exits.
+pgenv_configuration_dump_or_exit(){
+    local v=$1
+    local title=$2
+
+    CONF=$( pgenv_configuration_file_name $v )
+    if [ -r $CONF ]; then
+        echo -e "###############################\n#"
+        echo -e "#\n# $title\n# pgenv configuration for PostgreSQL $v"
+        echo -e "# File: $CONF "
+        echo -n "# Dumped on: " $( date )
+        echo -e "\n#\n# 8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-"
+        cat $CONF
+        echo -e "\n# ->8->8->8->8->8->8->8->8->8->8->8->8"
+        echo -e "#\n# End of configuration"
+        echo -e "###############################\n"
+    else
+        echo "No configuration found for version <$title> [$CONF]" >&2
+        exit 1
+    fi
+}
 
 # Function to load the configuration from a file.
 # A configuration file is a shell file that contains variables that
@@ -269,15 +319,11 @@ pgenv_current_version_number(){
 # to search for. A configuration file with such version number
 # will be used as configuration, and in the case it is missing, the default
 # configuration file will be used.
-pgenv_load_configuration(){
+pgenv_configuration_load(){
     local v=$1
 
-    PGENV_DEFAULT_CONFIG_FILE="${PGENV_ROOT}/.pgenv.conf"
-    if [ ! -z "$v" ]; then
-        PGENV_CONFIG_FILE="${PGENV_ROOT}/.pgenv.$v.conf"
-    else
-        PGENV_CONFIG_FILE=${PGENV_DEFAULT_CONFIG_FILE}
-    fi
+    PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
+    PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
 
     for conf in $( echo "$PGENV_CONFIG_FILE" "$PGENV_DEFAULT_CONFIG_FILE" )
     do
@@ -291,6 +337,118 @@ pgenv_load_configuration(){
     done
 
     pgenv_debug "No configuration loaded"
+}
+
+# Utility function to remove the configuration file.
+# It does remove the default file only if there are no more installed instances
+# on this system.
+pgenv_configuration_delete(){
+    local v=$1
+    PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
+    PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
+
+    # if the file is not here, nothing to do!
+    if [ ! -f "$PGENV_CONFIG_FILE" ]; then
+        return
+    fi
+
+    # if the file is the default one, delete only if there are
+    # no installed instances
+    if [ "$PGENV_CONFIG_FILE" = "$PGENV_DEFAULT_CONFIG_FILE" ]; then
+        local installed_versions=0
+        for installed in $( ls -d pgsql-* 2>/dev/null )
+        do
+            installed_versions=$(( installed_versions + 1 ))
+        done
+
+        if [ $installed_versions -gt 0 ]; then
+            pgenv_debug "Refusing to delete default configuration unless all instances are removed"
+            echo "Cannot delete default configuration while instances installed"
+            echo "You need to manually remove [$PGENV_CONFIG_FILE]"
+            return
+        fi
+    fi
+
+    # remove the file
+    pgenv_debug "Deleting configuration file [$PGENV_CONFIG_FILE]"
+    rm -f "$PGENV_CONFIG_FILE"
+    echo "Configuration file [$PGENV_CONFIG_FILE] deleted"
+}
+
+
+# Utility function to write a single variable in the configuration file.
+#
+# Accepts:
+# - the configuration file name to which write to
+# - the name of the variable
+# - the value of the variable
+# - an optional comment.
+#
+#
+# Invoking it as
+#   pgenv_configuration_write_variable 'pgenv.conf' 'foo' 'bar' 'A foo option'
+#
+# will result in the file in the following:
+#
+#   # A foo option
+#   foo=bar
+#
+# If the variable value is not set, the variable name is placed with a comment sign.
+pgenv_configuration_write_variable(){
+    local file=$1
+    local name=$2
+    local value=$3
+    local comment=$4
+
+    if [ ! -z "comment" ]; then
+        echo "# $comment" >> "$file"
+    fi
+
+    # if no value supplied, put a comment
+    if [ -z "$value" ]; then
+        echo -n "# " >> "$file"
+    fi
+    echo "${name}=${value}" >> "$file"
+    echo >> "$file"
+}
+
+# Writes the whole current configuration to the current version file
+# or the version file specified. It does a backup copy in the case
+# the file already exists.
+pgenv_configuration_write() {
+    local v=$1
+    CONF=$( pgenv_configuration_file_name $v )
+
+    # sanity check
+    if [ -z "$CONF" ]; then
+        echo "Cannot determine which configuration file to use!"
+        exit 1
+    fi
+
+    # make a backup copy
+    if [ -f "$CONF" ]; then
+        CONF_BACKUP="${CONF}.backup"
+        pgenv_debug "Making backup copy of [$CONF] into [$CONF_BACKUP]"
+        mv "$CONF" "$CONF_BACKUP"
+    fi
+
+    # ok, write the configuration
+    echo "# pgenv configuration created on $(date)" > "$CONF"
+    echo "" >> "$CONF"
+    pgenv_configuration_write_variable "$CONF" "PGENV_DEBUG" "" 'Enables debug output'
+    pgenv_configuration_write_variable "$CONF" "PGENV_STOP_MODE" "$PGENV_STOP_MODE" "Cluster stop mode for 'stop' and 'restart'"
+    pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" "Path to the cluster log file"
+    pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
+    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_INITDB" "$PGENV_FLAGS_INITDB" "Initdb flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_PLPERL" "$PGENV_PLPERL" 'Perl 5 executable to build PL/Perl'
+    pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLpython" 'Python executable to build PL/Perl'
+    pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
+    pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
+    pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
+    pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
+
+
+    echo "pgenv configuration file [$CONF] written"
 }
 
 
@@ -308,19 +466,26 @@ pgenv_start_instance(){
     fi
 
     # Init the database if needed.
-    if [ ! -d $PG_DATA ]; then
-        $INITDB
-    fi
+    pgenv_initdb
 
 
-    $PG_CTL start -w -l $PG_LOG
+    $PG_CTL start -w -l $PGENV_LOG -D "$PGDATA"
     if [ $? -eq 0 ]; then
         echo "PostgreSQL $v started"
-        echo "Logging to $PG_LOG"
+        echo "Logging to $PGENV_LOG"
     else
-        echo "PostgreSQL $v NOT started, examine logs in $PG_LOG"
+        echo "PostgreSQL $v NOT started, examine logs in $PGENV_LOG"
     fi
     trap 'exit' ERR
+}
+
+# Initializes and instance if no data directory is found.
+# Requires PG_DATA to be set.
+# It is safe to call multiple times.
+pgenv_initdb(){
+    if [ ! -d $PG_DATA ]; then
+        $INITDB "$PGENV_FLAGS_INITDB" -D "$PGDATA"
+    fi
 }
 
 # Wrapper function to stop or restart the current instance.
@@ -328,17 +493,17 @@ pgenv_start_instance(){
 # if 'stop' or 'restart' action need to be performed.
 pgenv_stop_or_restart_instance(){
     local command=$1
-    if $PG_CTL status &> /dev/null; then
+    if $PG_CTL status -D "$PGDATA"  &> /dev/null; then
         # ok, server running, apply the command
         case $command in
             stop)
-                $PG_CTL stop $PGENV_STOP_MODE
+                $PG_CTL stop -D "$PGDATA" $PGENV_STOP_MODE
                 echo "PostgreSQL $v stopped"
                 ;;
             restart)
-                $PG_CTL restart -l "$PG_LOG" $PGENV_STOP_MODE
+                $PG_CTL restart -D "$PGDATA" -l "$PGENV_LOG" $PGENV_STOP_MODE
                 echo "PostgreSQL $v restarted"
-                echo "Logging to $PG_LOG"
+                echo "Logging to $PGENV_LOG"
                 ;;
         esac
     else
@@ -348,9 +513,9 @@ pgenv_stop_or_restart_instance(){
                 echo "PostgreSQL $v not running"
                 ;;
             restart)
-                $PG_CTL start -l $PG_LOG
+                $PG_CTL start -D "$PGDATA" -l $PGENV_LOG
                 echo "PostgreSQL $v started"
-                echo "Logging to $PG_LOG"
+                echo "Logging to $PGENV_LOG"
                 ;;
         esac
     fi
@@ -361,7 +526,7 @@ case $1 in
         v=$2
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
         pgenv_installed_version_or_exit $v
-        pgenv_load_configuration $v
+        pgenv_configuration_load $v
 
         # Check if current version?
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then
@@ -369,8 +534,8 @@ case $1 in
         else
             # Shut down existing running instance.
             if [ -e "pgsql" ]; then
-                if $PG_CTL status &> /dev/null; then
-                    $PG_CTL stop
+                if $PG_CTL status -D "$PGDATA" &> /dev/null; then
+                    $PG_CTL stop -D "$PGDATA"
                 fi
             fi
 
@@ -379,15 +544,13 @@ case $1 in
         fi
 
         # Init if needed.
-        if [ ! -d $PG_DATA ]; then
-            $INITDB
-        fi
+        pgenv_initdb
 
         # Start er up!
-        if ! $PG_CTL status &> /dev/null; then
-            $PG_CTL start -l $PG_LOG
+        if ! $PG_CTL status -D "$PGDATA" &> /dev/null; then
+            $PG_CTL start -l $PGENV_LOG -D "$PGDATA"
             echo "PostgreSQL $v started"
-            echo "Logging to $PG_LOG"
+            echo "Logging to $PGENV_LOG"
         fi
         exit
         ;;
@@ -397,7 +560,7 @@ case $1 in
         pgenv_current_postgresql_or_exit
         v=$( pgenv_current_version_number )
         pgenv_debug "Current version $v"
-        pgenv_load_configuration $v
+        pgenv_configuration_load $v
 
         # Start er up!
         pgenv_start_instance
@@ -409,7 +572,7 @@ case $1 in
         pgenv_current_postgresql_or_exit
         v=$( pgenv_current_version_number )
         pgenv_debug "Current version $v"
-        pgenv_load_configuration $v
+        pgenv_configuration_load $v
 
         # either stop or restart
         command="$1"
@@ -452,7 +615,7 @@ case $1 in
         # sanity checks before building
         pgenv_input_version_or_exit "$v"
         pgenv_check_dependencies
-        pgenv_load_configuration $v
+        pgenv_configuration_load $v
 
         # Skip it if we already have it.
         if [ -e "pgsql-$v" ]; then
@@ -529,7 +692,7 @@ EOF
 
     clear)
         v=$( pgenv_current_postgresql_or_exit )
-        pgenv_load_configuration $v
+        pgenv_configuration_load $v
 
         # stop the instance
         pgenv_stop_or_restart_instance 'stop'
@@ -555,6 +718,8 @@ EOF
         rm -fr "pgsql-$v"
         rm -fr src/postgresql-$v.tar.* # could be .tar.bz2 or .tar.gz
         rm -fr src/postgresql-$v
+        pgenv_configuration_delete $v  # remove this particular configuration
+        pgenv_configuration_delete     # remove default configuration if no instances are left
         echo "PostgreSQL $v removed"
         exit
         ;;
@@ -687,6 +852,54 @@ EOF
     check)
         # check for all required dependencies
         pgenv_check_dependencies "verbose"
+        exit
+        ;;
+
+    config|configuration)
+        action=$2
+        v=$3
+
+        # which version does the user wants?
+        case "$v" in
+            version|current)
+                v=$( pgenv_current_version_number )
+                title='PostgreSQL currently in use'
+                ;;
+            default)
+                v=''
+                title='Default configuration'
+                ;;
+            *)
+                # get the currently in use if none specified
+                if [ -z "$v" ]; then
+                    v=$( pgenv_current_version_number )
+                fi
+
+                title="PostgreSQL $v"
+                ;;
+        esac
+
+
+        case $action in
+            show)
+                pgenv_configuration_dump_or_exit "$v" "$title" ;;
+            write)
+                pgenv_configuration_write "$v" ;;
+            edit)
+                configuration_file=$( pgenv_configuration_file_name $v )
+                if [ ! -z "$EDITOR" ]; then
+                    $EDITOR $configuration_file
+                else
+                    echo "No EDITOR variable set, fire up manually your editor to edit the file [$configuration_file]"
+                    exit 1
+                fi
+                ;;
+            delete)
+                pgenv_configuration_delete "$v" ;;
+            *)
+                echo "Configuration action \`$action\` not supported"
+                exit 1
+        esac
         exit
         ;;
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -27,8 +27,7 @@ INITDB="$PGSQL/bin/initdb"
 # Configuration variable and default settings
 
 PGENV_LOG=$PG_DATA/server.log
-PGENV_PG_USER="postgres"
-PGENV_INITDB_OPTS="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
+PGENV_INITDB_OPTS='-U postgres --locale en_US.UTF-8 --encoding UNICODE'
 PGENV_MAKE_OPTS="-j3"
 PGENV_CONFIGURE_OPTS=""
 PGENV_START_OPTS="-w"
@@ -127,7 +126,7 @@ pgenv_check_dependencies(){
 
         if [ ! -z "$interpreter" ]; then
             pgenv_debug "Configuring PL/${language} with ${interpreter}"
-            PGENV_CONFIGURE_PL+="--with-${language}  $( echo $language | tr 'a-z' 'A-Z' )=${interpreter} "
+            PGENV_CONFIGURE_OPTS+="--with-${language}  $( echo $language | tr 'a-z' 'A-Z' )=${interpreter} "
         fi
     }
 
@@ -453,18 +452,17 @@ pgenv_configuration_write() {
 
     echo "###### Build settings #####" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
-    pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" "Make flags"
-    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" "Configure flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" 'Make flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" 'Configure flags, without --prefix, --with-perl nor --with-python (they are dynamically computed)'
     pgenv_configuration_write_variable "$CONF" "PGENV_PERL" "$PGENV_PERL" 'Perl 5 executable to build PL/Perl'
-    pgenv_configuration_write_variable "$CONF" "PGENV_PYTHON" "$PGENV_PYTHON" 'Python executable to build PL/Perl'
+    pgenv_configuration_write_variable "$CONF" "PGENV_PYTHON" "$PGENV_PYTHON" 'Python executable to build PL/Python'
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
 
     echo "##### Runtime options #####" >> "$CONF"
-    pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" "Path to the cluster log file"
-    pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
-    pgenv_configuration_write_variable "$CONF" "PGENV_INITDB_OPTS" "$PGENV_INITDB_OPTS" "Initdb flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" 'Path to the cluster log file (mandatory)'
+    pgenv_configuration_write_variable "$CONF" "PGENV_INITDB_OPTS" "$PGENV_INITDB_OPTS" 'Initdb flags'
     pgenv_configuration_write_variable "$CONF" "PGENV_STOP_OPTS" "$PGENV_STOP_OPTS" 'Stop configuration flags'
     pgenv_configuration_write_variable "$CONF" "PGENV_STOP_MODE" "$PGENV_STOP_MODE" "Cluster stop mode for 'stop' and 'restart'"
     pgenv_configuration_write_variable "$CONF" "PGENV_START_OPTS" "$PGENV_START_OPTS" 'Start configuration flags'
@@ -491,8 +489,8 @@ pgenv_start_instance(){
     # Init the database if needed.
     pgenv_initdb
 
-    pgenv_debug "pg_ctl starting instance with flags [$PGENV_START_OPTS]"
-    $PG_CTL start -D "$PG_DATA" "$PGENV_START_OPTS" -l $PGENV_LOG
+    pgenv_debug "pg_ctl starting instance with flags [$PGENV_START_OPTS] log [$PGENV_LOG]"
+    $PG_CTL start -D "$PG_DATA" "$PGENV_START_OPTS" -l "$PGENV_LOG"
     if [ $? -eq 0 ]; then
         echo "PostgreSQL $v started"
         echo "Logging to $PGENV_LOG"
@@ -692,10 +690,9 @@ case $1 in
 EOF
         fi
 
-        # Configure: use the variable PGENV_CONFIGURE_PL for PL/Perl and PL/Python languages
-        # that have been auto-computed by pgenv_check_dependencies
-        pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL] + [$PGENV_CONFIGURE_OPTS]"
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_CONFIGURE_OPTS"
+
+        pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v] + [$PGENV_CONFIGURE_OPTS]"
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v "$PGENV_CONFIGURE_OPTS"
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then
@@ -915,6 +912,9 @@ EOF
             show)
                 pgenv_configuration_dump_or_exit "$v" "$title" ;;
             write)
+                # in an explicit write load first the variables from the runtime
+                # environment, so PL/Perl, make, and stuff can be already set
+                pgenv_check_dependencies
                 pgenv_configuration_write "$v" ;;
             edit)
                 configuration_file=$( pgenv_configuration_file_name $v )

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -260,11 +260,45 @@ pgenv_current_version_number(){
     echo $v
 }
 
+
+# Function to load the configuration from a file.
+# A configuration file is a shell file that contains variables that
+# will be 'sourced' into the current script runtime.
+#
+# The function accepts an optional argument which is the version number
+# to search for. A configuration file with such version number
+# will be used as configuration, and in the case it is missing, the default
+# configuration file will be used.
+pgenv_load_configuration(){
+    local v=$1
+
+    PGENV_DEFAULT_CONFIG_FILE="${PGENV_ROOT}/.pgenv.conf"
+    if [ ! -z "$v" ]; then
+        PGENV_CONFIG_FILE="${PGENV_ROOT}/.pgenv.$v.conf"
+    else
+        PGENV_CONFIG_FILE=${PGENV_DEFAULT_CONFIG_FILE}
+    fi
+
+    for conf in $( echo "$PGENV_CONFIG_FILE" "$PGENV_DEFAULT_CONFIG_FILE" )
+    do
+        pgenv_debug "Looking for configuration in $conf"
+
+        if [ -r "$conf" ]; then
+            pgenv_debug "Load configuration from [$conf]"
+            source "$conf"
+            break
+        fi
+    done
+
+    pgenv_debug "No configuration loaded"
+}
+
 case $1 in
     use)
         v=$2
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
         pgenv_installed_version_or_exit $v
+        pgenv_load_configuration $v
 
         # Check if current version?
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then
@@ -300,6 +334,7 @@ case $1 in
         pgenv_current_postgresql_or_exit
         v=$( pgenv_current_version_number )
         pgenv_debug "Current version $v"
+        pgenv_load_configuration $v
 
         # Just stop if already running.
         if $PG_CTL status &> /dev/null; then
@@ -330,6 +365,7 @@ case $1 in
         pgenv_current_postgresql_or_exit
         v=$( pgenv_current_version_number )
         pgenv_debug "Current version $v"
+        pgenv_load_configuration $v
 
         # either stop or restart
         command="$1"
@@ -399,6 +435,7 @@ case $1 in
         # sanity checks before building
         pgenv_input_version_or_exit "$v"
         pgenv_check_dependencies
+        pgenv_load_configuration $v
 
         # Skip it if we already have it.
         if [ -e "pgsql-$v" ]; then
@@ -475,6 +512,8 @@ EOF
 
     clear)
         v=$( pgenv_current_postgresql_or_exit )
+        pgenv_load_configuration $v
+
         if $PG_CTL status &> /dev/null; then
             $PG_CTL stop
             echo "PostgreSQL $v stopped"

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -31,6 +31,7 @@ PGENV_PG_USER="postgres"
 PGENV_FLAGS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
 PGENV_FLAGS_MAKE="-j3"
 PGENV_FLAGS_CONFIGURE=""
+PGENV_FLAGS_PGCTL_START="-w"
 #############################################
 
 # Prints a debug message if PGENV_DEBUG
@@ -276,8 +277,8 @@ pgenv_current_version_number(){
 # file is provided.
 pgenv_configuration_file_name(){
     local v=$1
+    local PGENV_DEFAULT_CONFIG_FILE="${PGENV_ROOT}/.pgenv.conf"
 
-    PGENV_DEFAULT_CONFIG_FILE="${PGENV_ROOT}/.pgenv.conf"
     if [ ! -z "$v" ]; then
         echo "${PGENV_ROOT}/.pgenv.$v.conf"
     else
@@ -296,7 +297,8 @@ pgenv_configuration_dump_or_exit(){
     local v=$1
     local title=$2
 
-    CONF=$( pgenv_configuration_file_name $v )
+    local CONF=$( pgenv_configuration_file_name $v )
+
     if [ -r $CONF ]; then
         echo -e "###############################\n#"
         echo -e "#\n# $title\n# pgenv configuration for PostgreSQL $v"
@@ -324,8 +326,8 @@ pgenv_configuration_dump_or_exit(){
 pgenv_configuration_load(){
     local v=$1
 
-    PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
-    PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
+    local PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
+    local PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
 
     for conf in $( echo "$PGENV_CONFIG_FILE" "$PGENV_DEFAULT_CONFIG_FILE" )
     do
@@ -334,7 +336,7 @@ pgenv_configuration_load(){
         if [ -r "$conf" ]; then
             pgenv_debug "Load configuration from [$conf]"
             source "$conf"
-            break
+            return
         fi
     done
 
@@ -346,13 +348,9 @@ pgenv_configuration_load(){
 # on this system.
 pgenv_configuration_delete(){
     local v=$1
-    PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
-    PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
+    local PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
+    local PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
 
-    # if the file is not here, nothing to do!
-    if [ ! -f "$PGENV_CONFIG_FILE" ]; then
-        return
-    fi
 
     # if the file is the default one, delete only if there are
     # no installed instances
@@ -364,11 +362,14 @@ pgenv_configuration_delete(){
         done
 
         if [ $installed_versions -gt 0 ]; then
-            pgenv_debug "Refusing to delete default configuration unless all instances are removed"
             echo "Cannot delete default configuration while instances installed"
-            echo "You need to manually remove [$PGENV_CONFIG_FILE]"
-            return
+            echo "If you really want to delete, manually remove [$PGENV_CONFIG_FILE]"
+            exit 1
         fi
+        # if the file is not here, nothing to do!
+      elif [ ! -f "$PGENV_CONFIG_FILE" ]; then
+            echo "No configuration to delete"
+            exit 1
     fi
 
     # remove the file
@@ -410,7 +411,7 @@ pgenv_configuration_write_variable(){
     if [ -z "$value" ]; then
         echo -n "# " >> "$file"
     fi
-    echo "${name}=${value}" >> "$file"
+    echo "${name}='${value}'" >> "$file"
     echo >> "$file"
 }
 
@@ -450,6 +451,7 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
+    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_START" "$PGENV_FLAGS_PGCTL_START" 'Start configuration flags'
 
 
     echo "pgenv configuration written to file [$CONF]"
@@ -464,7 +466,7 @@ pgenv_start_instance(){
     trap "" ERR
 
     # if the instance is already running, do nothing
-    if $PG_CTL status &> /dev/null; then
+    if $PG_CTL status -D "$PG_DATA" &> /dev/null; then
         echo "PostgreSQL $v is already running"
         return
     fi
@@ -473,7 +475,7 @@ pgenv_start_instance(){
     pgenv_initdb
 
 
-    $PG_CTL start -w -l $PGENV_LOG -D "$PGDATA"
+    $PG_CTL start -D "$PG_DATA" "$PGENV_FLAGS_PGCTL_START" -l $PGENV_LOG
     if [ $? -eq 0 ]; then
         echo "PostgreSQL $v started"
         echo "Logging to $PGENV_LOG"
@@ -488,7 +490,7 @@ pgenv_start_instance(){
 # It is safe to call multiple times.
 pgenv_initdb(){
     if [ ! -d $PG_DATA ]; then
-        $INITDB "$PGENV_FLAGS_INITDB" -D "$PGDATA"
+        $INITDB "$PGENV_FLAGS_INITDB" -D "$PG_DATA"
     fi
 }
 
@@ -497,15 +499,15 @@ pgenv_initdb(){
 # if 'stop' or 'restart' action need to be performed.
 pgenv_stop_or_restart_instance(){
     local command=$1
-    if $PG_CTL status -D "$PGDATA"  &> /dev/null; then
+    if $PG_CTL status -D "$PG_DATA"  &> /dev/null; then
         # ok, server running, apply the command
         case $command in
             stop)
-                $PG_CTL stop -D "$PGDATA" $PGENV_STOP_MODE
+                $PG_CTL stop -D "$PG_DATA" $PGENV_STOP_MODE
                 echo "PostgreSQL $v stopped"
                 ;;
             restart)
-                $PG_CTL restart -D "$PGDATA" -l "$PGENV_LOG" $PGENV_STOP_MODE
+                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" $PGENV_STOP_MODE
                 echo "PostgreSQL $v restarted"
                 echo "Logging to $PGENV_LOG"
                 ;;
@@ -517,7 +519,7 @@ pgenv_stop_or_restart_instance(){
                 echo "PostgreSQL $v not running"
                 ;;
             restart)
-                $PG_CTL start -D "$PGDATA" -l $PGENV_LOG
+                $PG_CTL start -D "$PG_DATA" -l $PGENV_LOG
                 echo "PostgreSQL $v started"
                 echo "Logging to $PGENV_LOG"
                 ;;
@@ -538,8 +540,8 @@ case $1 in
         else
             # Shut down existing running instance.
             if [ -e "pgsql" ]; then
-                if $PG_CTL status -D "$PGDATA" &> /dev/null; then
-                    $PG_CTL stop -D "$PGDATA"
+                if $PG_CTL status -D "$PG_DATA" &> /dev/null; then
+                    $PG_CTL stop -D "$PG_DATA"
                 fi
             fi
 
@@ -550,12 +552,8 @@ case $1 in
         # Init if needed.
         pgenv_initdb
 
-        # Start er up!
-        if ! $PG_CTL status -D "$PGDATA" &> /dev/null; then
-            $PG_CTL start -l $PGENV_LOG -D "$PGDATA"
-            echo "PostgreSQL $v started"
-            echo "Logging to $PGENV_LOG"
-        fi
+        # start the instance
+        pgenv_start_instance
         exit
         ;;
 
@@ -905,7 +903,11 @@ EOF
             delete)
                 pgenv_configuration_delete "$v" ;;
             *)
-                echo "Configuration action \`$action\` not supported"
+                if [ -z "$action" ]; then
+                    echo "You need to specify a \`config\` action to perform"
+                else
+                    echo "Configuration action \`$action\` not supported"
+                fi
                 exit 1
         esac
         exit

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -20,18 +20,18 @@ PG_DATA=$PGSQL/data
 PGENV_DOWNLOAD_ROOT='https://ftp.postgresql.org/pub/source/'
 
 # Now -w because 9.0 and earlier always time out even when successful.
-PG_CTL="$PGSQL/bin/pg_ctl "
-INITDB="$PGSQL/bin/initdb "
+PG_CTL="$PGSQL/bin/pg_ctl"
+INITDB="$PGSQL/bin/initdb"
 
 #############################################
 # Configuration variable and default settings
 
 PGENV_LOG=$PG_DATA/server.log
 PGENV_PG_USER="postgres"
-PGENV_FLAGS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
-PGENV_FLAGS_MAKE="-j3"
-PGENV_FLAGS_CONFIGURE=""
-PGENV_FLAGS_PGCTL_START="-w"
+PGENV_OPTS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
+PGENV_OPTS_MAKE="-j3"
+PGENV_OPTS_CONFIGURE=""
+PGENV_OPTS_PGCTL_START="-w"
 #############################################
 
 # Prints a debug message if PGENV_DEBUG
@@ -300,15 +300,13 @@ pgenv_configuration_dump_or_exit(){
     local CONF=$( pgenv_configuration_file_name $v )
 
     if [ -r $CONF ]; then
-        echo -e "###############################\n#"
-        echo -e "#\n# $title\n# pgenv configuration for PostgreSQL $v"
-        echo -e "# File: $CONF "
-        echo -n "# Dumped on: " $( date )
-        echo -e "\n#\n# 8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-8<-"
+
+        echo "# $title"
+        echo "# pgenv configuration for PostgreSQL $v"
+        echo "# File: $CONF"
+        echo "# ---------------------------------------------------"
         cat $CONF
-        echo -e "\n# ->8->8->8->8->8->8->8->8->8->8->8->8"
-        echo -e "#\n# End of configuration"
-        echo -e "###############################\n"
+        echo
     else
         echo "No configuration found for version <$title> [$CONF]" >&2
         exit 1
@@ -374,8 +372,9 @@ pgenv_configuration_delete(){
 
     # remove the file
     pgenv_debug "Deleting configuration file [$PGENV_CONFIG_FILE]"
-    rm -f "$PGENV_CONFIG_FILE"
-    echo "Configuration file [$PGENV_CONFIG_FILE] deleted"
+    rm -f "$PGENV_CONFIG_FILE"           # remove config file
+    rm -f "${PGENV_CONFIG_FILE}.backup"  # remove also backup file
+    echo "Configuration file [$PGENV_CONFIG_FILE] (and backup) deleted"
 }
 
 
@@ -442,21 +441,21 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_STOP_MODE" "$PGENV_STOP_MODE" "Cluster stop mode for 'stop' and 'restart'"
     pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" "Path to the cluster log file"
     pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
-    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_INITDB" "$PGENV_FLAGS_INITDB" "Initdb flags"
-    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_MAKE" "$PGENV_FLAGS_MAKE" "Make flags"
-    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_CONFIGURE" "$PGENV_FLAGS_CONFIGURE" "Configure flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_INITDB" "$PGENV_OPTS_INITDB" "Initdb flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_MAKE" "$PGENV_OPTS_MAKE" "Make flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_CONFIGURE" "$PGENV_OPTS_CONFIGURE" "Configure flags"
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPERL" "$PGENV_PLPERL" 'Perl 5 executable to build PL/Perl'
-    pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLpython" 'Python executable to build PL/Perl'
+    pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLPYTHON" 'Python executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
-    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_START" "$PGENV_FLAGS_PGCTL_START" 'Start configuration flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_stop" "$PGENV_FLAGS_PGCTL_STOP" 'Stop configuration flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_RESTART" "$PGENV_FLAGS_PGCTL_RESTART" 'Restart configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_PGCTL_START" "$PGENV_OPTS_PGCTL_START" 'Start configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_PGCTL_STOP" "$PGENV_OPTS_PGCTL_STOP" 'Stop configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_PGCTL_RESTART" "$PGENV_OPTS_PGCTL_RESTART" 'Restart configuration flags'
 
 
-    echo "pgenv configuration written to file [$CONF]"
+    echo "pgenv configuration written to file $CONF"
 }
 
 
@@ -476,8 +475,8 @@ pgenv_start_instance(){
     # Init the database if needed.
     pgenv_initdb
 
-    pgenv_debug "pg_ctl starting instance with flags [$PGENV_FLAGS_PGCTL_START]"
-    $PG_CTL start -D "$PG_DATA" "$PGENV_FLAGS_PGCTL_START" -l $PGENV_LOG
+    pgenv_debug "pg_ctl starting instance with flags [$PGENV_OPTS_PGCTL_START]"
+    $PG_CTL start -D "$PG_DATA" "$PGENV_OPTS_PGCTL_START" -l $PGENV_LOG
     if [ $? -eq 0 ]; then
         echo "PostgreSQL $v started"
         echo "Logging to $PGENV_LOG"
@@ -492,8 +491,8 @@ pgenv_start_instance(){
 # It is safe to call multiple times.
 pgenv_initdb(){
     if [ ! -d $PG_DATA ]; then
-        pgenv_debug "initdb running with flags [$PGENV_FLAGS_INITDB]"
-        $INITDB -D "$PG_DATA" "$PGENV_FLAGS_INITDB"
+        pgenv_debug "initdb running with flags [$PGENV_OPTS_INITDB]"
+        $INITDB -D "$PG_DATA" "$PGENV_OPTS_INITDB"
     else
         pgenv_debug "Directory $PG_DATA exists, not initdb-ing!"
     fi
@@ -508,13 +507,13 @@ pgenv_stop_or_restart_instance(){
         # ok, server running, apply the command
         case $command in
             stop)
-                pgenv_debug "pg_ctl stopping with mode [$PGENV_STOP_MODE] and flags [$PGENV_FLAGS_PGCTL_STOP]"
-                $PG_CTL stop -D "$PG_DATA" "$PGENV_STOP_MODE" "$PGENV_FLAGS_PGCTL_STOP"
+                pgenv_debug "pg_ctl stopping with mode [$PGENV_STOP_MODE] and flags [$PGENV_OPTS_PGCTL_STOP]"
+                $PG_CTL stop -D "$PG_DATA" "$PGENV_STOP_MODE" "$PGENV_OPTS_PGCTL_STOP"
                 echo "PostgreSQL $v stopped"
                 ;;
             restart)
-                pgenv_debug "pg_ctl restarting with mode [$PGENV_STOP_MODE] and flags [$PGENV_FLAGS_PGCTL_RESTART]"
-                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" "$PGENV_STOP_MODE" "$PGENV_FLAGS_PGCTL_RESTART"
+                pgenv_debug "pg_ctl restarting with mode [$PGENV_STOP_MODE] and flags [$PGENV_OPTS_PGCTL_RESTART]"
+                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" "$PGENV_STOP_MODE" "$PGENV_OPTS_PGCTL_RESTART"
                 echo "PostgreSQL $v restarted"
                 echo "Logging to $PGENV_LOG"
                 ;;
@@ -677,19 +676,19 @@ EOF
 
         # Configure: use the variable PGENV_CONFIGURE_PL for PL/Perl and PL/Python languages
         # that have been auto-computed by pgenv_check_dependencies
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_FLAGS_CONFIGURE"
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_OPTS_CONFIGURE"
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then
             # 8.x (and prior versions?) doesn't have `make world`.
-            $PGENV_MAKE "$PGENV_FLAGS_MAKE"
+            $PGENV_MAKE "$PGENV_OPTS_MAKE"
             $PGENV_MAKE install
             cd contrib
-            $PGENV_MAKE "$PGENV_FLAGS_MAKE"
+            $PGENV_MAKE "$PGENV_OPTS_MAKE"
             $PGENV_MAKE install
         else
             # Yay, make world!
-            $PGENV_MAKE world "$PGENV_FLAGS_MAKE"
+            $PGENV_MAKE world "$PGENV_OPTS_MAKE"
             $PGENV_MAKE install-world
         fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -28,10 +28,11 @@ INITDB="$PGSQL/bin/initdb"
 
 PGENV_LOG=$PG_DATA/server.log
 PGENV_PG_USER="postgres"
-PGENV_OPTS_INITDB="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
-PGENV_OPTS_MAKE="-j3"
-PGENV_OPTS_CONFIGURE=""
-PGENV_OPTS_PGCTL_START="-w"
+PGENV_INITDB_OPTS="-U $PGENV_PG_USER --locale en_US.UTF-8 --encoding UNICODE"
+PGENV_MAKE_OPTS="-j3"
+PGENV_CONFIGURE_OPTS=""
+PGENV_START_OPTS="-w"
+PGENV_STOP_OPTS=""
 #############################################
 
 # Prints a debug message if PGENV_DEBUG
@@ -438,21 +439,25 @@ pgenv_configuration_write() {
     echo "# pgenv configuration created on $(date)" > "$CONF"
     echo "" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_DEBUG" "" 'Enables debug output'
-    pgenv_configuration_write_variable "$CONF" "PGENV_STOP_MODE" "$PGENV_STOP_MODE" "Cluster stop mode for 'stop' and 'restart'"
-    pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" "Path to the cluster log file"
-    pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
-    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_INITDB" "$PGENV_OPTS_INITDB" "Initdb flags"
-    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_MAKE" "$PGENV_OPTS_MAKE" "Make flags"
-    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_CONFIGURE" "$PGENV_OPTS_CONFIGURE" "Configure flags"
+
+    echo "###### Build settings #####" >> "$CONF"
+    pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
+    pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" "Make flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" "Configure flags"
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPERL" "$PGENV_PLPERL" 'Perl 5 executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLPYTHON" 'Python executable to build PL/Perl'
-    pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
-    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_PGCTL_START" "$PGENV_OPTS_PGCTL_START" 'Start configuration flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_PGCTL_STOP" "$PGENV_OPTS_PGCTL_STOP" 'Stop configuration flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_OPTS_PGCTL_RESTART" "$PGENV_OPTS_PGCTL_RESTART" 'Restart configuration flags'
+
+    echo "##### Runtime options #####" >> "$CONF"
+    pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" "Path to the cluster log file"
+    pgenv_configuration_write_variable "$CONF" "PGENV_PG_USER" "$PGENV_PG_USER" "Cluster administrator user"
+    pgenv_configuration_write_variable "$CONF" "PGENV_INITDB_OPTS" "$PGENV_INITDB_OPTS" "Initdb flags"
+    pgenv_configuration_write_variable "$CONF" "PGENV_STOP_OPTS" "$PGENV_STOP_OPTS" 'Stop configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_STOP_MODE" "$PGENV_STOP_MODE" "Cluster stop mode for 'stop' and 'restart'"
+    pgenv_configuration_write_variable "$CONF" "PGENV_START_OPTS" "$PGENV_START_OPTS" 'Start configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_RESTART_OPTS" "$PGENV_RESTART_OPTS" 'Restart configuration flags'
 
 
     echo "pgenv configuration written to file $CONF"
@@ -475,8 +480,8 @@ pgenv_start_instance(){
     # Init the database if needed.
     pgenv_initdb
 
-    pgenv_debug "pg_ctl starting instance with flags [$PGENV_OPTS_PGCTL_START]"
-    $PG_CTL start -D "$PG_DATA" "$PGENV_OPTS_PGCTL_START" -l $PGENV_LOG
+    pgenv_debug "pg_ctl starting instance with flags [$PGENV_START_OPTS]"
+    $PG_CTL start -D "$PG_DATA" "$PGENV_START_OPTS" -l $PGENV_LOG
     if [ $? -eq 0 ]; then
         echo "PostgreSQL $v started"
         echo "Logging to $PGENV_LOG"
@@ -491,8 +496,8 @@ pgenv_start_instance(){
 # It is safe to call multiple times.
 pgenv_initdb(){
     if [ ! -d $PG_DATA ]; then
-        pgenv_debug "initdb running with flags [$PGENV_OPTS_INITDB]"
-        $INITDB -D "$PG_DATA" "$PGENV_OPTS_INITDB"
+        pgenv_debug "initdb running with flags [$PGENV_INITDB_OPTS]"
+        $INITDB -D "$PG_DATA" "$PGENV_INITDB_OPTS"
     else
         pgenv_debug "Directory $PG_DATA exists, not initdb-ing!"
     fi
@@ -507,13 +512,13 @@ pgenv_stop_or_restart_instance(){
         # ok, server running, apply the command
         case $command in
             stop)
-                pgenv_debug "pg_ctl stopping with mode [$PGENV_STOP_MODE] and flags [$PGENV_OPTS_PGCTL_STOP]"
-                $PG_CTL stop -D "$PG_DATA" "$PGENV_STOP_MODE" "$PGENV_OPTS_PGCTL_STOP"
+                pgenv_debug "pg_ctl stopping with mode [$PGENV_STOP_MODE] and flags [$PGENV_STOP_OPTS]"
+                $PG_CTL stop -D "$PG_DATA" "$PGENV_STOP_MODE" "$PGENV_STOP_OPTS"
                 echo "PostgreSQL $v stopped"
                 ;;
             restart)
-                pgenv_debug "pg_ctl restarting with mode [$PGENV_STOP_MODE] and flags [$PGENV_OPTS_PGCTL_RESTART]"
-                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" "$PGENV_STOP_MODE" "$PGENV_OPTS_PGCTL_RESTART"
+                pgenv_debug "pg_ctl restarting with mode [$PGENV_STOP_MODE] and flags [$PGENV_RESTART_OPTS]"
+                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" "$PGENV_STOP_MODE" "$PGENV_RESTART_OPTS"
                 echo "PostgreSQL $v restarted"
                 echo "Logging to $PGENV_LOG"
                 ;;
@@ -676,19 +681,19 @@ EOF
 
         # Configure: use the variable PGENV_CONFIGURE_PL for PL/Perl and PL/Python languages
         # that have been auto-computed by pgenv_check_dependencies
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_OPTS_CONFIGURE"
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_CONFIGURE_OPTS"
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then
             # 8.x (and prior versions?) doesn't have `make world`.
-            $PGENV_MAKE "$PGENV_OPTS_MAKE"
+            $PGENV_MAKE "$PGENV_MAKE_OPTS"
             $PGENV_MAKE install
             cd contrib
-            $PGENV_MAKE "$PGENV_OPTS_MAKE"
+            $PGENV_MAKE "$PGENV_MAKE_OPTS"
             $PGENV_MAKE install
         else
             # Yay, make world!
-            $PGENV_MAKE world "$PGENV_OPTS_MAKE"
+            $PGENV_MAKE world "$PGENV_MAKE_OPTS"
             $PGENV_MAKE install-world
         fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -879,6 +879,8 @@ EOF
         ;;
 
     check)
+        # load default configuration
+        pgenv_configuration_load
         # check for all required dependencies
         pgenv_check_dependencies "verbose"
         exit

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -293,6 +293,69 @@ pgenv_load_configuration(){
     pgenv_debug "No configuration loaded"
 }
 
+
+# Wrapper function to start the current instance.
+# If the instance is already running, nothing happens.
+# If the instance does not have already a PG_DATA
+# directory, it will be initdb-ed.
+pgenv_start_instance(){
+    trap "" ERR
+
+    # if the instance is already running, do nothing
+    if $PG_CTL status &> /dev/null; then
+        echo "PostgreSQL $v is already running"
+        return
+    fi
+
+    # Init the database if needed.
+    if [ ! -d $PG_DATA ]; then
+        $INITDB
+    fi
+
+
+    $PG_CTL start -w -l $PG_LOG
+    if [ $? -eq 0 ]; then
+        echo "PostgreSQL $v started"
+        echo "Logging to $PG_LOG"
+    else
+        echo "PostgreSQL $v NOT started, examine logs in $PG_LOG"
+    fi
+    trap 'exit' ERR
+}
+
+# Wrapper function to stop or restart the current instance.
+# Accepts an optional argument 'command' that specifies
+# if 'stop' or 'restart' action need to be performed.
+pgenv_stop_or_restart_instance(){
+    local command=$1
+    if $PG_CTL status &> /dev/null; then
+        # ok, server running, apply the command
+        case $command in
+            stop)
+                $PG_CTL stop $PGENV_STOP_MODE
+                echo "PostgreSQL $v stopped"
+                ;;
+            restart)
+                $PG_CTL restart -l "$PG_LOG" $PGENV_STOP_MODE
+                echo "PostgreSQL $v restarted"
+                echo "Logging to $PG_LOG"
+                ;;
+        esac
+    else
+        # server not running
+        case $command in
+            stop)
+                echo "PostgreSQL $v not running"
+                ;;
+            restart)
+                $PG_CTL start -l $PG_LOG
+                echo "PostgreSQL $v started"
+                echo "Logging to $PG_LOG"
+                ;;
+        esac
+    fi
+}
+
 case $1 in
     use)
         v=$2
@@ -336,27 +399,8 @@ case $1 in
         pgenv_debug "Current version $v"
         pgenv_load_configuration $v
 
-        # Just stop if already running.
-        if $PG_CTL status &> /dev/null; then
-            echo "PostgreSQL $v is already running"
-            exit
-        fi
-
-        # Init the database if needed.
-        if [ ! -d $PG_DATA ]; then
-            $INITDB
-        fi
-
         # Start er up!
-        trap "" ERR
-        $PG_CTL start -w -l $PG_LOG
-        if [ $? -eq 0 ]; then
-            echo "PostgreSQL $v started"
-            echo "Logging to $PG_LOG"
-        else
-            echo "PostgreSQL $v NOT started, examine logs in $PG_LOG"
-        fi
-
+        pgenv_start_instance
         exit
         ;;
 
@@ -398,35 +442,8 @@ case $1 in
         pgenv_debug "Stop mode set to [$PGENV_STOP_MODE]"
 
 
-
-
-        # Test if the server is running
-        if $PG_CTL status &> /dev/null; then
-            # ok, server running, apply the command
-            case $command in
-                stop)
-                    $PG_CTL stop $PGENV_STOP_MODE
-                    echo "PostgreSQL $v stopped"
-                    ;;
-                restart)
-                    $PG_CTL restart -l "$PG_LOG" $PGENV_STOP_MODE
-                    echo "PostgreSQL $v restarted"
-                    echo "Logging to $PG_LOG"
-                    ;;
-            esac
-        else
-            # server not running
-            case $command in
-                stop)
-                    echo "PostgreSQL $v not running"
-                    ;;
-                restart)
-                    $PG_CTL start -l $PG_LOG
-                    echo "PostgreSQL $v started"
-                    echo "Logging to $PG_LOG"
-                    ;;
-            esac
-        fi
+        # stop the current instance (or restart it)
+        pgenv_stop_or_restart_instance $command
         exit
         ;;
 
@@ -514,10 +531,8 @@ EOF
         v=$( pgenv_current_postgresql_or_exit )
         pgenv_load_configuration $v
 
-        if $PG_CTL status &> /dev/null; then
-            $PG_CTL stop
-            echo "PostgreSQL $v stopped"
-        fi
+        # stop the instance
+        pgenv_stop_or_restart_instance 'stop'
 
         # We know a version is in use, since pgenv_current_postgresql_or_exit
         # otherwise would have killed the script.

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -913,6 +913,7 @@ EOF
                     echo "Configuration action \`$action\` not supported"
                 fi
                 exit 1
+                ;;
         esac
         exit
         ;;

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -131,22 +131,33 @@ pgenv_check_dependencies(){
         fi
     }
 
-    PGENV_MAKE=$(which make)
     if [ -z "$PGENV_MAKE" ]; then
-        PGENV_MAKE=$(which gmake)
+        PGENV_MAKE=$(which make)
+        if [ -z "$PGENV_MAKE" ]; then
+            PGENV_MAKE=$(which gmake)
+        fi
     fi
     pgenv_detail_command "make" $PGENV_MAKE
 
-    PGENV_CURL=$(which curl)
+
+    if [ -z "$PGENV_CURL" ]; then
+        PGENV_CURL=$(which curl)
+    fi
     pgenv_detail_command "curl" $PGENV_CURL
 
-    PGENV_PATCH=$(which patch)
+    if [ -z "$PGENV_PATCH" ]; then
+        PGENV_PATCH=$(which patch)
+    fi
     pgenv_detail_command "patch" $PGENV_PATCH
 
-    PGENV_TAR=$(which tar)
+    if [ -z "$PGENV_TAR" ]; then
+        PGENV_TAR=$(which tar)
+    fi
     pgenv_detail_command "tar" $PGENV_TAR
 
-    PGENV_SED=$(which sed)
+    if [ -z "$PGENV_SED" ]; then
+        PGENV_SED=$(which sed)
+    fi
     pgenv_detail_command "sed" $PGENV_SED
 
     # if PGENV_PERL has been set from outside
@@ -444,8 +455,8 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" "Make flags"
     pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" "Configure flags"
-    pgenv_configuration_write_variable "$CONF" "PGENV_PLPERL" "$PGENV_PLPERL" 'Perl 5 executable to build PL/Perl'
-    pgenv_configuration_write_variable "$CONF" "PGENV_PLPYTHON" "$PGENV_PLPYTHON" 'Python executable to build PL/Perl'
+    pgenv_configuration_write_variable "$CONF" "PGENV_PERL" "$PGENV_PERL" 'Perl 5 executable to build PL/Perl'
+    pgenv_configuration_write_variable "$CONF" "PGENV_PYTHON" "$PGENV_PYTHON" 'Python executable to build PL/Perl'
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
@@ -625,8 +636,10 @@ case $1 in
         v=$2
         # sanity checks before building
         pgenv_input_version_or_exit "$v"
-        pgenv_check_dependencies
         pgenv_configuration_load $v
+        pgenv_check_dependencies
+
+
 
         # Skip it if we already have it.
         if [ -e "pgsql-$v" ]; then
@@ -681,6 +694,7 @@ EOF
 
         # Configure: use the variable PGENV_CONFIGURE_PL for PL/Perl and PL/Python languages
         # that have been auto-computed by pgenv_check_dependencies
+        pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL] + [$PGENV_CONFIGURE_OPTS]"
         ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_PL "$PGENV_CONFIGURE_OPTS"
 
         # make and make install

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -452,6 +452,8 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
     pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_START" "$PGENV_FLAGS_PGCTL_START" 'Start configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_stop" "$PGENV_FLAGS_PGCTL_STOP" 'Stop configuration flags'
+    pgenv_configuration_write_variable "$CONF" "PGENV_FLAGS_PGCTL_RESTART" "$PGENV_FLAGS_PGCTL_RESTART" 'Restart configuration flags'
 
 
     echo "pgenv configuration written to file [$CONF]"
@@ -474,7 +476,7 @@ pgenv_start_instance(){
     # Init the database if needed.
     pgenv_initdb
 
-
+    pgenv_debug "pg_ctl starting instance with flags [$PGENV_FLAGS_PGCTL_START]"
     $PG_CTL start -D "$PG_DATA" "$PGENV_FLAGS_PGCTL_START" -l $PGENV_LOG
     if [ $? -eq 0 ]; then
         echo "PostgreSQL $v started"
@@ -490,6 +492,7 @@ pgenv_start_instance(){
 # It is safe to call multiple times.
 pgenv_initdb(){
     if [ ! -d $PG_DATA ]; then
+        pgenv_debug "initdb running with flags [$PGENV_FLAGS_INITDB]"
         $INITDB "$PGENV_FLAGS_INITDB" -D "$PG_DATA"
     fi
 }
@@ -503,11 +506,13 @@ pgenv_stop_or_restart_instance(){
         # ok, server running, apply the command
         case $command in
             stop)
-                $PG_CTL stop -D "$PG_DATA" $PGENV_STOP_MODE
+                pgenv_debug "pg_ctl stopping with mode [$PGENV_STOP_MODE] and flags [$PGENV_FLAGS_PGCTL_STOP]"
+                $PG_CTL stop -D "$PG_DATA" "$PGENV_STOP_MODE" "$PGENV_FLAGS_PGCTL_STOP"
                 echo "PostgreSQL $v stopped"
                 ;;
             restart)
-                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" $PGENV_STOP_MODE
+                pgenv_debug "pg_ctl restarting with mode [$PGENV_STOP_MODE] and flags [$PGENV_FLAGS_PGCTL_RESTART]"
+                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" "$PGENV_STOP_MODE" "$PGENV_FLAGS_PGCTL_RESTART"
                 echo "PostgreSQL $v restarted"
                 echo "Logging to $PGENV_LOG"
                 ;;
@@ -519,9 +524,7 @@ pgenv_stop_or_restart_instance(){
                 echo "PostgreSQL $v not running"
                 ;;
             restart)
-                $PG_CTL start -D "$PG_DATA" -l $PGENV_LOG
-                echo "PostgreSQL $v started"
-                echo "Logging to $PGENV_LOG"
+                pgenv_start_instance
                 ;;
         esac
     fi


### PR DESCRIPTION
This is a proposal for the configuration management.

The ide is to store variables in a file that is sourced into the script when required. The cofniguration file can be either a per-version file, e.g., `.pgenv.10.5.conf` for the 10.5 version, or `.pgenv.conf` for the default configuration to use every time a specific one is not found.
The configuration file is loaded at the very last time, so if it does not exists, command line variables win.

All major commands have been refactored to support the configuration flags, and this required to make all pg_ctl usage wrapped in specific functions.

The brnch adds a `config` command that supports subcommands to `write`, `edit`, `show` and `delete` a specific configuration.