### PR TITLE
Configure opts cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,8 @@ project directory (generally in `~/.pgenv`.). If you'd like them to live
 elsewhere, set the `$PGENV_ROOT` environment variable to the appropriate
 directory.
 
-pgenv compiles each version with support for PL/Perl and PL/Python when it can
-find their interpreters, or by using the values of the `$PGENV_PERL` and
-`$PGENV_PYTHON` variables. See [`pgenv build`](#pgenv-build) below for
-details.
-
+It is possible to configure which programs, flags and languages to build
+using a configuration file before the program launches the build. 
 For a more detailed configuration, see the [`pgenv config`](#pgenv-config)
 command below.
 
@@ -114,8 +111,11 @@ $ git pull
 *   sed, grep, cat, tar - General Unix command line utilities
 *   patch - For patching versions that need patching
 *   make -  Builds PostgreSQL
-*   Perl 5 - To build PL/Perl (optional)
-*   Python - To build PL/Python (optional)
+
+Optional dependencies:
+
+*   Perl 5 - To build PL/Perl 
+*   Python - To build PL/Python
 
 Command Reference
 -----------------
@@ -191,27 +191,16 @@ before building. If the version is already built, it will not be rebuilt; use
     # [Curl, configure, and make output elided]
     PostgreSQL 10.3 built
 
-The build will include PL/Perl and PL/Python if `pgenv` can find their
-interpreters in the current environment. To manually configure PL/Perl and
-PL/Python support, set the `$PGENV_PERL` or `$PGENV_PYTHON` to the location of
-the desired interpreters. The behavior for both variables is as follows:
+In order to build an instance with PL/Perl, PL/Python, PL/Tcl and more in
+general with particular `configure` flags, write first the configuration
+and ajust the `PGENV_CONFIGURE_OPTS` line to include specific
+flags, so for instance:
 
--   If the variable is empty or not set, `pgenv` will look for an interpreter in
-    the current path.
--   If the variable points to an executable representing the language
-    interpreter, the procedural language will be configured using that
-    executable.
--   If the variable is set to a non-executable value, such as `no`, the
-    procedural language will not be built.
-
-For example, the following will build PostgreSQL 10.5 without PL/Perl and with
-a specific version of Python:
-
-    $ PGENV_PERL=no PGENV_PYTHON=/usr/python/2.7/bin/python pgenv build 10.5
-
-You can also set the `PGENV_PERL` and `PGENV_PYTHON` variables in the
-configuration file (see [pgenv config](#pgenv-config)).
-
+    $ pgenv config write 10.5
+    $ pgenv config edit 10.5
+    # adjust PGENV_CONFIGURE_OPTS
+    $ pgenv build 10.5
+    
 ### pgenv remove
 
 Removes the specified version of PostgreSQL unless it is the currently-active
@@ -407,11 +396,6 @@ PGENV_MAKE_OPTS='-j3'
 # Configure flags
 # PGENV_CONFIGURE_OPTS=''
 
-# Perl 5 executable to build PL/Perl
-# PGENV_PLPERL=''
-
-# Python executable to build PL/Perl
-# PGENV_PLPYTHON=''
 
 # ...
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ Initializes the data directory if none exists.
 
     $ pgenv start
     PostgreSQL started
+    
+It is possible to specify flags to pass to `pg_ctl(1)` when performing the
+`START` action, setting the `PGENV_START_OPTS` in the [configuration](#pgenv-config).
+Such options must not include the data directory, nor the log file.
 
 ### pgenv stop
 
@@ -226,32 +230,8 @@ Stops the currently active version of PostgreSQL.
     $ pgenv stop
     PostgreSQL 10.5 stopped
 
-Optionally pass a `pg_ctl` stop mode:
-
-    $ pgenv stop immediate
-    PostgreSQL 10.5 stopped
-
-Or specify it in the `PGENV_STOP_MODE` environment or [config](#pgenv-config))
-variable:
-
-    $ PGENV_STOP_MODE="immediate" pgenv stop
-    PostgreSQL 10.5 stopped
-
-The supported modes are:
-
-- `smart`
-- `fast`
-- `immediate`
-
-With no stop mode specified, the server's default stop mode will be used, and
-varies by PostgreSQL release. See the `pg_ctl(1)` documentation for more
-information about stop modes.
-
-It is worth noting that the command-line argument stop mode takes precedence
-over the `PGENV_STOP_MODE` variable; for example, the following will stop the
-server in `immediate` mode:
-
-    PGENV_STOP_MODE="fast" pgenv stop immediate
+It is possible to specify flags to pass to `pg_ctl(1)` when performing the
+`stop` action, setting the `PGENV_STOP_OPTS` in the [configuration](#pgenv-config).
 
 ### pgenv restart
 
@@ -262,11 +242,9 @@ already running.
     PostgreSQL 10.1 restarted
     Logging to pgsql/data/server.log
 
-As with the `stop` command, `restart` takes an optional `pg_ctl` stop mode
-argument and respects the `PGENV_STOP_MODE` variable:
+It is possible to specify flags to pass to `pg_ctl(1)` when performing the
+`restart` action, setting the `PGENV_RESTART_OPTS` in the [configuration](#pgenv-config).
 
-    $ pgenv restart immediate
-    $ PGENV_STOP_MODE="immediate" pgenv restart
 
 ### pgenv available
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -104,32 +104,16 @@ pgenv_check_dependencies(){
     pgenv_detail_command(){
         local command_name=$1
         local command=$2
-        local language=$3
 
         local nl=$'\n'
         local tab=$'\t'
         if [ -z "$command" ]; then
-            if [ -z "$language" ]; then
                 missing+="[KO] $command_name:${tab}NOT found!$nl"
-            else
-                warning+="[KO] $command_name:${tab}NOT found - Cannot build $language: try setting $( echo PGENV_${command_name} | tr 'a-z' 'A-Z'  )$nl"
-            fi
         else
             present+="[OK] $command_name:$tab$command$nl"
         fi
     }
 
-    # Appends a language interpreter configuration
-    # to the 'configure' variable used to build the system
-    pgenv_configure_pl(){
-        local language=$1
-        local interpreter=$2
-
-        if [ ! -z "$interpreter" ]; then
-            pgenv_debug "Configuring PL/${language} with ${interpreter}"
-            PGENV_CONFIGURE_OPTS+=" --with-${language}  $( echo $language | tr 'a-z' 'A-Z' )=${interpreter} "
-        fi
-    }
 
     if [ -z "$PGENV_MAKE" ]; then
         PGENV_MAKE=$(which make)
@@ -159,26 +143,6 @@ pgenv_check_dependencies(){
         PGENV_SED=$(which sed)
     fi
     pgenv_detail_command "sed" $PGENV_SED
-
-    # if PGENV_PERL has been set from outside
-    # of the script and points to an executable
-    # use that, otherwise try to figure it out
-    if [ -z "$PGENV_PERL" ]; then
-        PGENV_PERL=$(which perl)
-    elif [ ! -x "$PGENV_PERL" ]; then
-        PGENV_PERL=""
-    fi
-    pgenv_detail_command "perl" "$PGENV_PERL" "PL/Perl"
-    pgenv_configure_pl "perl" $PGENV_PERL
-
-    # same reason for python
-    if [ -z "$PGENV_PYTHON" ]; then
-        PGENV_PYTHON=$(which python)
-    elif [ ! -x "$PGENV_PYTHON" ]; then
-        PGENV_PYTHON=""
-    fi
-    pgenv_detail_command "python" "$PGENV_PYTHON" "PL/Python"
-    pgenv_configure_pl "python" $PGENV_PYTHON
 
 
     # Go back to exiting on error.
@@ -464,9 +428,8 @@ pgenv_configuration_write() {
     echo "###### Build settings #####" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" 'Make flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" '' 'Configure flags, without --prefix, --with-perl nor --with-python (they are dynamically computed)'
-    pgenv_configuration_write_variable "$CONF" "PGENV_PERL" "$PGENV_PERL" 'Perl 5 executable to build PL/Perl'
-    pgenv_configuration_write_variable "$CONF" "PGENV_PYTHON" "$PGENV_PYTHON" 'Python executable to build PL/Python'
+    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" '' 'Configure flags, including PL languages but without --prefix'
+
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -438,7 +438,6 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_LOG" "$PGENV_LOG" 'Path to the cluster log file (mandatory)'
     pgenv_configuration_write_variable "$CONF" "PGENV_INITDB_OPTS" "$PGENV_INITDB_OPTS" 'Initdb flags'
     pgenv_configuration_write_variable "$CONF" "PGENV_STOP_OPTS" "$PGENV_STOP_OPTS" 'Stop configuration flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_STOP_MODE" "$PGENV_STOP_MODE" "Cluster stop mode for 'stop' and 'restart'"
     pgenv_configuration_write_variable "$CONF" "PGENV_START_OPTS" "$PGENV_START_OPTS" 'Start configuration flags'
     pgenv_configuration_write_variable "$CONF" "PGENV_RESTART_OPTS" "$PGENV_RESTART_OPTS" 'Restart configuration flags'
 
@@ -495,13 +494,13 @@ pgenv_stop_or_restart_instance(){
         # ok, server running, apply the command
         case $command in
             stop)
-                pgenv_debug "pg_ctl stopping with mode [$PGENV_STOP_MODE] and flags [$PGENV_STOP_OPTS]"
-                $PG_CTL stop -D "$PG_DATA" $PGENV_STOP_MODE $PGENV_STOP_OPTS
+                pgenv_debug "pg_ctl stopping with  flags [$PGENV_STOP_OPTS]"
+                $PG_CTL stop -D "$PG_DATA" $PGENV_STOP_OPTS
                 echo "PostgreSQL $v stopped"
                 ;;
             restart)
-                pgenv_debug "pg_ctl restarting with mode [$PGENV_STOP_MODE] and flags [$PGENV_RESTART_OPTS]"
-                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG" $PGENV_STOP_MODE $PGENV_RESTART_OPTS
+                pgenv_debug "pg_ctl restarting with flags [$PGENV_RESTART_OPTS]"
+                $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG"  $PGENV_RESTART_OPTS
                 echo "PostgreSQL $v restarted"
                 echo "Logging to $PGENV_LOG"
                 ;;
@@ -570,34 +569,6 @@ case $1 in
 
         # either stop or restart
         command="$1"
-
-        # if the user specified a stop mode
-        # use it, otherwise the PGENV_STOP_MODE
-        # variable will be used.
-        if [ ! -z "$2" ]; then
-            stop_mode="$2"
-        else
-            stop_mode=$PGENV_STOP_MODE
-        fi
-
-        case $stop_mode in
-            f|fast)
-                PGENV_STOP_MODE="--mode=fast"
-                ;;
-            i|immediate)
-                PGENV_STOP_MODE="--mode=immediate"
-                ;;
-            s|smart)
-                PGENV_STOP_MODE="--mode=smart"
-                ;;
-            *)
-                # do not allow the user to screw up pg_ctl flags!
-                PGENV_STOP_MODE=""
-                ;;
-        esac
-
-        pgenv_debug "Stop mode set to [$PGENV_STOP_MODE]"
-
 
         # stop the current instance (or restart it)
         pgenv_stop_or_restart_instance $command

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -428,7 +428,7 @@ pgenv_configuration_write() {
     echo "###### Build settings #####" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" 'Make flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" '' 'Configure flags, including PL languages but without --prefix'
+    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" Configure flags, including PL languages but without --prefix'
 
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -428,7 +428,7 @@ pgenv_configuration_write() {
     echo "###### Build settings #####" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" 'Make flags'
-    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" Configure flags, including PL languages but without --prefix'
+    pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" 'Configure flags, including PL languages but without --prefix'
 
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
@@ -612,18 +612,6 @@ case $1 in
         pgenv_check_dependencies
 
 
-        # warn if no configuration was loaded
-        if [ -z "$PGENV_CONFIGURATION_FILE" ]; then
-            echo "WARNING: no configuration file found for version $v"
-            echo "if you wish to customize the build process please"
-            echo "stop the execution within 5 seconds and run first"
-            echo "    pgenv config write $v && pgenv config edit $v"
-            echo "adjust configure and make options and flags and run again"
-            echo "    pgenv build $v"
-            echo
-            sleep 5
-        fi
-
         # Skip it if we already have it.
         if [ -e "pgsql-$v" ]; then
             echo "PostgreSQL $v already built"
@@ -651,6 +639,20 @@ case $1 in
         if [ ! -f $PG_TARBALL ]; then
             $PGENV_CURL -fLO ${PGENV_DOWNLOAD_ROOT}/v$v/${PG_TARBALL}
         fi
+
+
+        # warn if no configuration was loaded
+        if [ -z "$PGENV_CONFIGURATION_FILE" ]; then
+            echo "WARNING: no configuration file found for version $v"
+            echo "if you wish to customize the build process please"
+            echo "stop the execution within 5 seconds and run first"
+            echo "    pgenv config write $v && pgenv config edit $v"
+            echo "adjust configure and make options and flags and run again"
+            echo "    pgenv build $v"
+            echo
+            sleep 5
+        fi
+
 
         # Unpack the source.
         rm -rf "postgresql-$v"

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -612,6 +612,17 @@ case $1 in
         pgenv_check_dependencies
 
 
+        # warn if no configuration was loaded
+        if [ -z "$PGENV_CONFIGURATION_FILE" ]; then
+            echo "WARNING: no configuration file found for version $v"
+            echo "if you wish to customize the build process please"
+            echo "stop the execution within 5 seconds and run first"
+            echo "    pgenv config write $v && pgenv config edit $v"
+            echo "adjust configure and make options and flags and run again"
+            echo "    pgenv build $v"
+            echo
+            sleep 5
+        fi
 
         # Skip it if we already have it.
         if [ -e "pgsql-$v" ]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -126,8 +126,8 @@ pgenv_check_dependencies(){
         local interpreter=$2
 
         if [ ! -z "$interpreter" ]; then
-                pgenv_debug "Configuring PL/${language} with ${interpreter}"
-                PGENV_CONFIGURE_OPTS+=" --with-${language}  $( echo $language | tr 'a-z' 'A-Z' )=${interpreter} "
+            pgenv_debug "Configuring PL/${language} with ${interpreter}"
+            PGENV_CONFIGURE_OPTS+=" --with-${language}  $( echo $language | tr 'a-z' 'A-Z' )=${interpreter} "
         fi
     }
 
@@ -337,11 +337,16 @@ pgenv_configuration_dump_or_exit(){
 # to search for. A configuration file with such version number
 # will be used as configuration, and in the case it is missing, the default
 # configuration file will be used.
+#
+# The function sets the PGENV_CONFIGURATION_FILE variable to the name of the
+# file loaded or to an empty string. This helps understanding later on
+# if the configuration has been loaded.
 pgenv_configuration_load(){
     local v=$1
 
     local PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
     local PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
+    PGENV_CONFIGURATION_FILE=''
 
     for conf in $( echo "$PGENV_CONFIG_FILE" "$PGENV_DEFAULT_CONFIG_FILE" )
     do
@@ -350,6 +355,7 @@ pgenv_configuration_load(){
         if [ -r "$conf" ]; then
             pgenv_debug "Load configuration from [$conf]"
             source "$conf"
+            PGENV_CONFIGURATION_FILE="$conf"
             return
         fi
     done


### PR DESCRIPTION
The rationale behind this PR is to simplify the configuration and variable management avoiding clashes.
So far, two variables were used to drive the PL configuration: `PGENV_PERL` and `PGENV_PYTHON`. Those two variables were setting `configure` options that could clash with `PGENV_CONFIGURE_OPTS`. Since now there is support for a configuration file, the user can directly manipulate `PGENV_CONFIGURE_OPTS` instead of having to manage it and the former two variables.
Same for cluster stop modes (variable `PGENV_STOP_MODE` could clash with `PGENV_STOP_OPTS`).

Advantages: 

- a more "standard" approach (user is required to set configure or pg_ctl variables);
- less code in the script and less conflicting conditions

Disadvantage: 
- the script is a little less "automatic".

My idea is to squash this into master, if approved.
This breaks compatibility with previous versions using the removed variables.