### PR TITLE
Patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ git pull
 *   env - Sets environment for execution
 *   bash - Command shell interpreter
 *   curl - Used to download files
-*   sed, grep, cat, tar, sort, tr - General Unix command line utilities
+*   sed, grep, cat, tar, sort, tr, uname - General Unix command line utilities
 *   patch - For patching versions that need patching
 *   make -  Builds PostgreSQL
 
@@ -183,8 +183,10 @@ running, `clear` will stop it before clearing it.
 ### pgenv build
 
 Downloads and builds the specified version of PostgreSQL and its contrib
-modules, as far back as 8.0. PostgreSQL versions 8.0 and 8.1 will be patched
-before building. If the version is already built, it will not be rebuilt; use
+modules, as far back as 8.0. 
+It is possible to instrument the build process to patch the source tree, see
+the section on patching later on.
+If the version is already built, it will not be rebuilt; use
 `clear` to remove an existing version before building it again.
 
     $ pgenv build 10.3
@@ -226,7 +228,40 @@ pass it on the command line at the time of build:
 
    $ PERL=/usr/local/my-fancy-perl pgenv build 10.5
    
-  
+#### Patching
+
+`pgenv` can patch the source tree before the build process starts.
+In particular, the `patch/` folder can contain a set of index files
+and patch to apply. The process searches for an index file corresponding
+to the PostgreSQL version to build, and if found applies all the patches
+contained into the index.
+
+Index files are searched using the PostgreSQL version, or parts of it, and
+the operating system type. For example, in the case of the PostgreSQL version
+8.1.4 the index files is searched among one of the following:
+
+      $PGENV_ROOT/patch/index/patch.8.1.4.Linux
+      $PGENV_ROOT/patch/index/patch.8.1.4
+      $PGENV_ROOT/patch/index/patch.8.1.Linux
+      $PGENV_ROOT/patch/index/patch.8.1
+      $PGENV_ROOT/patch/index/patch.8.Linux
+      $PGENV_ROOT/patch/index/patch.8
+
+
+This allows you to specify an index for pretty much any combination or grouping desired.
+The first index file that matches wins and is used for the build process. 
+If no index file is found within the list, no patching is applied at all.
+
+The index file must contain a list of patches to apply, that is file names (either absolute
+or relative to the `patch/` subfolder). Each individual file is applied thru `patch(1)`.
+
+It is possible to specify a particular index file, that means avoid the automatic index selection,
+by either setting the `PGENV_PATCH_INDEX` variable on the command line or in the configuration
+file. As an example
+
+    $ PGENV_PATCH_INDEX=/src/my-patch-list.txt pgenv build 10.5
+
+
 
 ### pgenv remove
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,15 @@ and patch to apply. The process searches for an index file corresponding
 to the PostgreSQL version to build, and if found applies all the patches
 contained into the index.
 
-Index files are searched using the PostgreSQL version, or parts of it, and
-the operating system type. For example, in the case of the PostgreSQL version
+Index files are named after the PostgreSQL version and the Operating System;
+in particular the name of an index file is composed as `patch.<version>.<os>`
+where `version` is the PostgreSQL version number (or a part of it) and
+`os` is the Operating System. As an example, `patch.8.1.4.Linux` represents
+the index used when building PostgreSQL 8.1.4 on a Linux machine.
+To provide more flexibility, the system searches for an index that is named
+after the exact PostgreSQL version and Operating System or a mix of
+possible combinations of those.
+As an example, in the case of the PostgreSQL version
 8.1.4 the index files is searched among one of the following:
 
       $PGENV_ROOT/patch/index/patch.8.1.4.Linux
@@ -249,8 +256,8 @@ the operating system type. For example, in the case of the PostgreSQL version
 
 
 This allows you to specify an index for pretty much any combination or grouping desired.
-The first index file that matches wins and is used for the build process. 
-If no index file is found within the list, no patching is applied at all.
+The first index file that matches wins and it is the only one used for the build process. 
+If no index file is found at all, no patching is applied on the source tree.
 
 The index file must contain a list of patches to apply, that is file names (either absolute
 or relative to the `patch/` subfolder). Each individual file is applied thru `patch(1)`.

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -435,6 +435,8 @@ pgenv_configuration_write() {
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE_OPTS" "$PGENV_MAKE_OPTS" 'Make flags'
     pgenv_configuration_write_variable "$CONF" "PGENV_CONFIGURE_OPTS" "$PGENV_CONFIGURE_OPTS" 'Configure flags, including PL languages but without --prefix'
 
+    pgenv_configuration_write_variable "$CONF" "PGENV_PATCH_INDEX" "$PGENV_PATCH_INDEX" 'A file that lists ordered patches to apply before building starts'
+
     pgenv_configuration_write_variable "$CONF" "PGENV_CURL" "$PGENV_CURL" 'Curl command to download source code'
     pgenv_configuration_write_variable "$CONF" "PGENV_PATCH" "$PGENV_PATCH" 'Patch command for specific versions'
     pgenv_configuration_write_variable "$CONF" "PGENV_SED" "$PGENV_SED" 'Sed used to manipulate strings'
@@ -522,6 +524,109 @@ pgenv_stop_or_restart_instance(){
         esac
     fi
 }
+
+
+# A function to provide the list, in the right order, of
+# patch index files to try for patching the source tree.
+# The idea is that the priority goes to an index that matches
+# the exact version and the OS-type, then the exact PostgreSQL version,
+# and iterates reducing the version to major/minor and finally to
+# major only. For example, for the version 8.1.4:
+#
+#
+#  patch/index/patch.8.1.4.Linux
+#  patch/index/patch.8.1.4
+#  patch/index/patch.8.1.Linux
+#  patch/index/patch.8.1
+#  patch/index/patch.8.Linux
+#  patch/index/patch.8
+#
+# The first file found must win.
+pgenv_patch_get_index_file_names(){
+    local version=$1
+
+    local brand=$( echo $version | $PGENV_SED 's/\([[:digit:]]\{1,2\}\).*/\1/' )
+    local year=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.\([[:digit:]]\{1,2\}\).*/\1/' )
+
+    # show all the files in the correct order
+    cat <<EOF
+$PGENV_ROOT/patch/index/patch.$version.$(uname -s)
+$PGENV_ROOT/patch/index/patch.$version
+$PGENV_ROOT/patch/index/patch.$brand.$year.$(uname -s)
+$PGENV_ROOT/patch/index/patch.$brand.$year
+$PGENV_ROOT/patch/index/patch.$brand.$(uname -s)
+$PGENV_ROOT/patch/index/patch.$brand
+EOF
+
+}
+
+
+# Utility function to patch a source tree.
+# The function accepts a version number, that is the version number of PostgreSQL
+# that is going to be built. The function gets the list of available patch index files
+# and reads the first one that exists.
+# The patch index, in turn, contains a list of patches to be applied in an
+# ordered manner.
+#
+# The second, optional, argument for the function is the "verbose" argument,
+# that if not empty, makes the function to print out a message for
+# every patch.
+pgenv_patch_source_tree() {
+    local version=$1
+    local verbose=$2
+    local current_patch
+
+    # skip all on an empty version
+    if [ -z "$version" ]; then
+        return
+    fi
+
+    # see what index to apply
+    if [ -z "$PGENV_PATCH_INDEX" ]; then
+        for current_patch in  $( pgenv_patch_get_index_file_names $version )
+        do
+            if [ -r "$current_patch" ]; then
+                PGENV_PATCH_INDEX=$current_patch
+                break
+            fi
+        done
+    fi
+
+
+    pgenv_debug "Patch index file [$PGENV_PATCH_INDEX]"
+    if [ ! -r "$PGENV_PATCH_INDEX" ]; then
+        # no patch to apply
+        pgenv_debug "Skipping patch: no index file found!"
+        return
+    fi
+
+    # if here, apply all the patches listed in the index file
+    for current_patch in $( cat "$PGENV_PATCH_INDEX" )
+    do
+        # is the current patch file name relative or absolute?
+        case "$current_patch" in
+            /*) ;;
+            *) current_patch="$PGENV_ROOT/patch/$current_patch" ;;
+        esac
+
+        if [ -r "$current_patch" ]; then
+            pgenv_debug "Applying patch [$current_patch] into source tree $( pwd )"
+            $PGENV_PATCH -s -p1 < "$current_patch"
+
+            # if in verbose mode, print out
+            # a status message about this patch
+            if [ ! -z "$verbose" ]; then
+                if [ $? -eq 0 ]; then
+                    echo -n "Applied"
+                else
+                    echo -n "NOT applied"
+                fi
+                echo " patch $current_patch"
+            fi
+        fi
+    done
+}
+
 
 case $1 in
     use)
@@ -635,23 +740,9 @@ case $1 in
         $PGENV_TAR $TAR_OPTS $PG_TARBALL
         cd postgresql-$v
 
-        # Patch 8.1.
-        # XXXX Consider moving to a file, adding patches for older versions.
-        if [[ $v =~ ^8\.[01]\. ]]; then
-            $PGENV_PATCH -p1 <<EOF
---- a/src/pl/plperl/plperl.c
-+++ b/src/pl/plperl/plperl.c
-@@ -694,7 +694,7 @@
- 		if (!isGV_with_GP(sv) || !GvCV(sv))
- 			continue;
- 		SvREFCNT_dec(GvCV(sv)); /* free the CV */
--		GvCV(sv) = NULL;		/* prevent call via GV */
-+		GvCV_set(sv, NULL);		/* prevent call via GV */
- 	}
- 
- 	hv_clear(stash);
-EOF
-        fi
+        # patch the source tree if required
+        pgenv_debug "Patching version $v"
+        pgenv_patch_source_tree "$v" 'verbose'
 
 
         pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v] + [$PGENV_CONFIGURE_OPTS]"

--- a/patch/8.0/8.0.plperl.patch
+++ b/patch/8.0/8.0.plperl.patch
@@ -1,0 +1,11 @@
+--- a/src/pl/plperl/plperl.c
++++ b/src/pl/plperl/plperl.c
+@@ -694,7 +694,7 @@
+ 		if (!isGV_with_GP(sv) || !GvCV(sv))
+ 			continue;
+ 		SvREFCNT_dec(GvCV(sv)); /* free the CV */
+-		GvCV(sv) = NULL;		/* prevent call via GV */
++		GvCV_set(sv, NULL);		/* prevent call via GV */
+ 	}
+
+ 	hv_clear(stash);

--- a/patch/index/patch.8.0
+++ b/patch/index/patch.8.0
@@ -1,0 +1,1 @@
+8.0/8.0.plperl.patch

--- a/patch/index/patch.8.1
+++ b/patch/index/patch.8.1
@@ -1,0 +1,1 @@
+8.0/8.0.plperl.patch


### PR DESCRIPTION
This is a proposal for the *patching feature*. The idea is to be able to instrument the build process to patch the source tree.

To instrument the build system a *patch index* file must be created, such file contains a list of files to apply via `patch`. Each file listed can be with a relative name (relative to the `patch/` subfolder) or an absolute path.

The index is searched on a per-version basis with the precedence to the OS type (`uname -s`). If no file is found for the specific version, the process searches for an index file with less details, so for instance for version 8.1.4 the list of searched files is:

```
patch/index/patch.8.1.4.Linux
patch/index/patch.8.1.4
patch/index/patch.8.1.Linux
patch/index/patch.8.1
patch/index/patch.8.Linux
patch/index/patch.8
```

for a Linux kernel/OS. If no index is found, nothing is patched at all.
This allows the user to get better control over the patching process and allows for a "global" patch for a brand release or a specific operating system.

I've refactored the patch for 8.0 and 8.1 but it is not working, at least on 8.1.4, could it be it has been overtaken?