### PR TITLE
Message verbosity

### DIFF
--- a/bin/pgenv
+++ b/bin/pgenv
@@ -4,11 +4,53 @@
 trap 'exit' ERR
 set -E
 
+# message levels, used by pgenv_message
+declare -A msg_levels
+msg_levels[debug]=5
+msg_levels[info]=10
+msg_levels[warn]=20
+msg_levels[error]=25
+msg_levels[always]=999
+
+
+
+# Prints a message of text to STDERR.
+# The function accepts two arguments:
+# 1) the message to print
+# 2) an optional level (by default 'always' that is show always the message)
+#
+# The message is printed only if the value of the variable
+# PGENV_VERBOSITY is the same of the level.
+pgenv_message(){
+    local level=$2
+    local current_level=0
+    local defined_level=0
+
+    # default to info
+    if [ -z "$level" ]; then
+        level='always' # always display!
+    fi
+
+    if [ -z "$PGENV_VERBOSITY" ]; then
+        PGENV_VERBOSITY='info'
+    fi
+
+    # get the message priority as a numeric value
+    current_level=${msg_levels[$level]}
+    defined_level=${msg_levels[$PGENV_VERBOSITY]}
+
+    if [ $current_level -ge $defined_level ]; then
+        echo "$1" >&2
+    fi
+}
+
+
+
 # Set PGENV_ROOT only if not already set.
 if [ -z "$PGENV_ROOT" ]; then
     PGENV_ROOT=$(dirname $(dirname $0))
 else
-    echo "Using PGENV_ROOT $PGENV_ROOT" >&2
+    pgenv_message "Using PGENV_ROOT $PGENV_ROOT" 'warn'
 fi
 
 cd $PGENV_ROOT
@@ -34,13 +76,6 @@ PGENV_START_OPTS=""
 PGENV_STOP_OPTS=""
 #############################################
 
-# Prints a debug message if PGENV_DEBUG
-# variable enabled
-pgenv_debug(){
-    if [ ! -z "$PGENV_DEBUG" ]; then
-        echo "[DEBUG] $1" >&2
-    fi
-}
 
 pgenv_versions() {
     if [ -e "pgsql" ]; then
@@ -196,13 +231,13 @@ pgenv_input_version_or_exit() {
 
         # if no version is installed, suggest the user to build one
         if [ $installed_versions -eq 0 ]; then
-            echo "No PostgreSQL version is installed!"
-            echo "Are you looking for command \`$hint\` instead?"
+            pgenv_message "No PostgreSQL version is installed!"
+            pgenv_message "Are you looking for command \`$hint\` instead?"
             exit 1
         else
             # at least one version is available,
             # ask more details to the user
-            echo "Which version of PostgreSQL do you want?"
+            pgenv_message "Which version of PostgreSQL do you want?"
             if [ ! -z "$verbose" ]; then
                 pgenv_versions
             fi
@@ -215,7 +250,7 @@ pgenv_input_version_or_exit() {
     elif [[ $version =~ ^[1-9][1-9](beta|rc)[1-9]?$ ]]; then
         return # versions 11beta1 and alike
     else
-        echo "Value \"$version\" does not appear to be a PostgreSQL valid version number"
+        pgenv_message "Value \"$version\" does not appear to be a PostgreSQL valid version number"
         exit 1
     fi
 }
@@ -227,7 +262,7 @@ pgenv_input_version_or_exit() {
 pgenv_installed_version_or_exit(){
     local version=$1
     if [ ! -e "pgsql-${version}" ]; then
-        echo "PostgreSQL $version not installed; installed versions:"
+        pgenv_message "PostgreSQL $version not installed; installed versions:"
         pgenv_versions
         exit 1
     fi
@@ -237,9 +272,9 @@ pgenv_installed_version_or_exit(){
 # and aborts the script.
 pgenv_current_postgresql_or_exit(){
     if [ ! -e "pgsql" ]; then
-        echo "No version of PostgreSQL currently in use"
-        echo "Run \`pgenv use \$version\` to link and start a specific version"
-        echo "Run \`pgenv versions\` to list all installed versions"
+        pgenv_message "No version of PostgreSQL currently in use"
+        pgenv_message "Run \`pgenv use \$version\` to link and start a specific version"
+        pgenv_message "Run \`pgenv versions\` to list all installed versions"
         exit 1
     fi
 }
@@ -319,17 +354,17 @@ pgenv_configuration_load(){
 
     for conf in $( echo "$PGENV_CONFIG_FILE" "$PGENV_DEFAULT_CONFIG_FILE" )
     do
-        pgenv_debug "Looking for configuration in $conf"
+        pgenv_message "Looking for configuration in $conf" 'debug'
 
         if [ -r "$conf" ]; then
-            pgenv_debug "Load configuration from [$conf]"
+            pgenv_message "Load configuration from [$conf]" 'debug'
             source "$conf"
             PGENV_CONFIGURATION_FILE="$conf"
             return
         fi
     done
 
-    pgenv_debug "No configuration loaded"
+    pgenv_message "No configuration loaded" 'info'
 }
 
 # Utility function to remove the configuration file.
@@ -351,21 +386,21 @@ pgenv_configuration_delete(){
         done
 
         if [ $installed_versions -gt 0 ]; then
-            echo "Cannot delete default configuration while version configurations exist"
-            echo "To remove it anyway, delete $PGENV_CONFIG_FILE"
+            pgenv_message "Cannot delete default configuration while version configurations exist"
+            pgenv_message "To remove it anyway, delete $PGENV_CONFIG_FILE"
             exit 1
         fi
         # if the file is not here, nothing to do!
       elif [ ! -f "$PGENV_CONFIG_FILE" ]; then
-            echo "No configuration to delete"
+            pgenv_message "No configuration to delete"
             exit 1
     fi
 
     # remove the file
-    pgenv_debug "Deleting configuration file [$PGENV_CONFIG_FILE]"
+    pgenv_message "Deleting configuration file [$PGENV_CONFIG_FILE]" 'debug'
     rm -f "$PGENV_CONFIG_FILE"           # remove config file
     rm -f "${PGENV_CONFIG_FILE}.backup"  # remove also backup file
-    echo "Configuration file $PGENV_CONFIG_FILE (and backup) deleted"
+    pgenv_message "Configuration file $PGENV_CONFIG_FILE (and backup) deleted"
 }
 
 
@@ -414,21 +449,21 @@ pgenv_configuration_write() {
 
     # sanity check
     if [ -z "$CONF" ]; then
-        echo "Cannot determine which configuration file to use!"
+        pgenv_message "Cannot determine which configuration file to use!"
         exit 1
     fi
 
     # make a backup copy
     if [ -f "$CONF" ]; then
         CONF_BACKUP="${CONF}.backup"
-        pgenv_debug "Making backup copy of [$CONF] into [$CONF_BACKUP]"
+        pgenv_message "Making backup copy of [$CONF] into [$CONF_BACKUP]" 'debug'
         mv "$CONF" "$CONF_BACKUP"
     fi
 
     # ok, write the configuration
     echo "# pgenv configuration created on $(date)" > "$CONF"
     echo "" >> "$CONF"
-    pgenv_configuration_write_variable "$CONF" "PGENV_DEBUG" "" 'Enables debug output'
+    pgenv_configuration_write_variable "$CONF" "PGENV_VERBOSITY" "" "Enables verbose output, set to \'info', 'debug' or none"
 
     echo "###### Build settings #####" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
@@ -460,20 +495,20 @@ pgenv_start_instance(){
 
     # if the instance is already running, do nothing
     if $PG_CTL status -D "$PG_DATA" &> /dev/null; then
-        echo "PostgreSQL $v is already running"
+        pgenv_message "PostgreSQL $v is already running"
         return
     fi
 
     # Init the database if needed.
     pgenv_initdb
 
-    pgenv_debug "pg_ctl starting instance with flags [$PGENV_START_OPTS] log [$PGENV_LOG]"
+    pgenv_message "pg_ctl starting instance with flags [$PGENV_START_OPTS] log [$PGENV_LOG]" 'debug'
     $PG_CTL start -D "$PG_DATA"  -l "$PGENV_LOG" $PGENV_START_OPTS
     if [ $? -eq 0 ]; then
-        echo "PostgreSQL $v started"
-        echo "Logging to $PGENV_LOG"
+        pgenv_message "PostgreSQL $v started"
+        pgenv_message "Logging to $PGENV_LOG"
     else
-        echo "PostgreSQL $v NOT started, examine logs in $PGENV_LOG"
+        pgenv_message "PostgreSQL $v NOT started, examine logs in $PGENV_LOG"
     fi
     trap 'exit' ERR
 }
@@ -483,10 +518,10 @@ pgenv_start_instance(){
 # It is safe to call multiple times.
 pgenv_initdb(){
     if [ ! -d $PG_DATA ]; then
-        pgenv_debug "initdb running with flags [$PGENV_INITDB_OPTS]"
+        pgenv_message "initdb running with flags [$PGENV_INITDB_OPTS]" 'debug'
         $INITDB -D "$PG_DATA" $PGENV_INITDB_OPTS
     else
-        pgenv_debug "Directory $PG_DATA exists, not initdb-ing!"
+        pgenv_message "Directory $PG_DATA exists, not initdb-ing!" 'debug'
     fi
 }
 
@@ -499,22 +534,22 @@ pgenv_stop_or_restart_instance(){
         # ok, server running, apply the command
         case $command in
             stop)
-                pgenv_debug "pg_ctl stopping with  flags [$PGENV_STOP_OPTS]"
+                pgenv_message "pg_ctl stopping with  flags [$PGENV_STOP_OPTS]" 'debug'
                 $PG_CTL stop -D "$PG_DATA" $PGENV_STOP_OPTS
-                echo "PostgreSQL $v stopped"
+                pgenv_message "PostgreSQL $v stopped"
                 ;;
             restart)
-                pgenv_debug "pg_ctl restarting with flags [$PGENV_RESTART_OPTS]"
+                pgenv_message "pg_ctl restarting with flags [$PGENV_RESTART_OPTS]" 'debug'
                 $PG_CTL restart -D "$PG_DATA" -l "$PGENV_LOG"  $PGENV_RESTART_OPTS
-                echo "PostgreSQL $v restarted"
-                echo "Logging to $PGENV_LOG"
+                pgenv_message "PostgreSQL $v restarted"
+                pgenv_message "Logging to $PGENV_LOG"
                 ;;
         esac
     else
         # server not running
         case $command in
             stop)
-                echo "PostgreSQL $v not running"
+                pgenv_message "PostgreSQL $v not running"
                 ;;
             restart)
                 pgenv_start_instance
@@ -532,7 +567,7 @@ case $1 in
 
         # Check if current version?
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then
-            echo "Already using PostgreSQL $v"
+            pgenv_message "Already using PostgreSQL $v"
         else
             # Shut down existing running instance.
             if [ -e "pgsql" ]; then
@@ -557,7 +592,7 @@ case $1 in
         # check a version is currently in use
         pgenv_current_postgresql_or_exit
         v=$( pgenv_current_version_number )
-        pgenv_debug "Current version $v"
+        pgenv_message "Current version $v" 'debug'
         pgenv_configuration_load $v
 
         # Start er up!
@@ -569,7 +604,7 @@ case $1 in
         # check a version is currently in use
         pgenv_current_postgresql_or_exit
         v=$( pgenv_current_version_number )
-        pgenv_debug "Current version $v"
+        pgenv_message "Current version $v" 'debug'
         pgenv_configuration_load $v
 
         # either stop or restart
@@ -590,7 +625,7 @@ case $1 in
 
         # Skip it if we already have it.
         if [ -e "pgsql-$v" ]; then
-            echo "PostgreSQL $v already built"
+            pgenv_message "PostgreSQL $v already built"
             exit
         fi
 
@@ -619,13 +654,13 @@ case $1 in
 
         # warn if no configuration was loaded
         if [ -z "$PGENV_CONFIGURATION_FILE" ]; then
-            echo "WARNING: no configuration file found for version $v"
-            echo "HINT: if you wish to customize the build process please"
-            echo "stop the execution within 5 seconds (CTRL-c) and run "
-            echo "    pgenv config write $v && pgenv config edit $v"
-            echo "adjust 'configure' and 'make' options and flags and run again"
-            echo "    pgenv build $v"
-            echo
+            pgenv_message "WARNING: no configuration file found for version $v"
+            pgenv_message "HINT: if you wish to customize the build process please"
+            pgenv_message "stop the execution within 5 seconds (CTRL-c) and run "
+            pgenv_message "    pgenv config write $v && pgenv config edit $v"
+            pgenv_message "adjust 'configure' and 'make' options and flags and run again"
+            pgenv_message "    pgenv build $v"
+            pgenv_message
             sleep 5
         fi
 
@@ -654,7 +689,7 @@ EOF
         fi
 
 
-        pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v] + [$PGENV_CONFIGURE_OPTS]"
+        pgenv_message "configure command line [--prefix=$PGENV_ROOT/pgsql-$v] + [$PGENV_CONFIGURE_OPTS]" 'debug'
         # need to keep a single string to pass to configure or
         # will get an 'invalid package'
         ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_OPTS
@@ -677,7 +712,7 @@ EOF
         # write the configuration
         pgenv_configuration_write "$v"
 
-        echo "PostgreSQL $v built"
+        pgenv_message "PostgreSQL $v built"
         exit
         ;;
 
@@ -691,7 +726,7 @@ EOF
         # We know a version is in use, since pgenv_current_postgresql_or_exit
         # otherwise would have killed the script.
         rm -f pgsql
-        echo "PostgreSQL $v cleared"
+        pgenv_message "PostgreSQL $v cleared"
         exit
         ;;
 
@@ -700,9 +735,9 @@ EOF
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
 
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then
-            echo "PostgreSQL $v currently in use"
-            echo "Run \`pgenv clear\` to clear it"
-            echo "or \`pgenv use\` to switch to another version"
+            pgenv_message "PostgreSQL $v currently in use"
+            pgenv_message "Run \`pgenv clear\` to clear it"
+            pgenv_message "or \`pgenv use\` to switch to another version"
             exit 1
         fi
 
@@ -711,7 +746,7 @@ EOF
         rm -fr src/postgresql-$v
         pgenv_configuration_delete $v  # remove this particular configuration
         pgenv_configuration_delete     # remove default configuration if no instances are left
-        echo "PostgreSQL $v removed"
+        pgenv_message "PostgreSQL $v removed"
         exit
         ;;
 
@@ -752,7 +787,7 @@ EOF
                               | sed 's/\/$//')
         do
             major=$( echo $version | $PGENV_SED 's/\([[:digit:]]\{1,2\}\).*/\1/' )
-            pgenv_debug "Extracted major version [$major]"
+            pgenv_message "Extracted major version [$major]" 'debug'
 
             # check the version is a number!
             if [[ $major =~ ^[0-9]+$ ]] ; then
@@ -768,7 +803,7 @@ EOF
                     minor=$( echo $version | $PGENV_SED 's/[[:digit:]]\.\([[:digit:]]\{1,2\}\).*/\1/' )
                 fi
                 major=$(( major * 10 + minor ))
-                pgenv_debug "Normalized major version [$major]"
+                pgenv_message "Normalized major version [$major]" 'debug'
                 # append the current version to the hash
                 # indexed by the major version
                 versions_hash[ "$major" ]+="${version}-"
@@ -779,8 +814,8 @@ EOF
         # the download did go wrong
         keys=$( echo ${!versions_hash[@]} )
         if [ -z "$keys" ]; then
-            echo "No versions found at URL <$PGENV_DOWNLOAD_ROOT>"
-            pgenv_debug "Hash content: ${!versions_hash[@]}"
+            pgenv_message "No versions found at URL <$PGENV_DOWNLOAD_ROOT>"
+            pgenv_message "Hash content: ${!versions_hash[@]}" 'debug'
             exit 1
         fi
 
@@ -812,13 +847,13 @@ EOF
                 done
 
                 if [ $must_print -ne 1 ]; then
-                    pgenv_debug "Skip major version $current_version (required $*)"
+                    pgenv_message "Skip major version $current_version (required $*)" 'debug'
                     continue
                 fi
             fi
 
-            echo "                     PostgreSQL $current_version"
-            echo "    ------------------------------------------------"
+            pgenv_message "                     PostgreSQL $current_version"
+            pgenv_message "    ------------------------------------------------"
             printed=0
             for numeric in $( echo ${versions_hash[$major]} \
                                   | tr '-' '\n'  \
@@ -891,7 +926,7 @@ EOF
                 if [ ! -z "$EDITOR" ]; then
                     $EDITOR $configuration_file
                 else
-                    echo "No EDITOR variable set, manually start your editor to edit $configuration_file"
+                    pgenv_message "No EDITOR variable set, manually start your editor to edit $configuration_file"
                     exit 1
                 fi
                 ;;
@@ -899,9 +934,9 @@ EOF
                 pgenv_configuration_delete "$v" ;;
             *)
                 if [ -z "$action" ]; then
-                    echo "You need to specify a \`config\` action to perform"
+                    pgenv_message "You need to specify a \`config\` action to perform"
                 else
-                    echo "Configuration action \`$action\` not supported"
+                    pgenv_message "Configuration action \`$action\` not supported"
                 fi
                 exit 1
                 ;;
@@ -911,7 +946,7 @@ EOF
 
     *)
         if [ $# -gt 0 ]; then
-            echo "Unknown command \`$1\`"
+            pgenv_message "Unknown command \`$1\`"
         fi
 
         pgenv_help


### PR DESCRIPTION
This is related to discussion about issue #21 and the need for displaying messages at different level of verbosity.
The idea is to replace `pgenv_debug` with a more general `pgenv_message` that accepts the verbosity level as an argument (so `pgenv_message 'debug'` is the same as the old `pgenv_debug`). The message is printed only if the required level is lesser than the `PGENV_VERBOSITY` configuration, which defaults to print every message if not specified in the configuration (the above replaces the variable `PGENV_DEBUG`).
Levels are kept in an associative array.