### PR TITLE
Build from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ git pull
 *   sed, grep, cat, tar, sort, tr, uname - General Unix command line utilities
 *   patch - For patching versions that need patching
 *   make - Builds PostgreSQL
-*   git - Used to download the current source tree
+*   git - Used to fetch the current development source tree
 
 Optional dependencies:
 
@@ -293,7 +293,7 @@ will fetch updates from the repository.
 It is possible to configure both the repository and the branch or checkout to fetch
 using the variables:
 - `PGENV_POSTGRESQL_REPOSITORY` which defaults to `https://git.postgresql.org/git/postgresql.git`;
-- `PGENV_POSTGRESQL_REPOSITORY_CHECKOUT` which if not set defaults to fetching the `master` branch, while if set creates a tracking branch.
+- `PGENV_POSTGRESQL_REPOSITORY_BRANCH` defines a specific branch other than the repository default one to checkout or pull.
 
 The above variable have not been included in the configuration mechanism because they
 represent advanced tweaks. It is however possible to include them in the configuration file
@@ -412,7 +412,7 @@ the following:
         stop       Stop the current PostgreSQL server
         restart    Restart the current PostgreSQL server
         build      Build a specific version of PostgreSQL
-        build-git  Build the development version ouf of git repository
+        build-dev  Build the development source tree pulled from the PostgreSQL repository
         remove     Remove a specific version of PostgreSQL
         version    Show the current PostgreSQL version
         current    Same as 'version'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Synopsis
     # Build PostgreSQL server
     pgenv build 10.4
     
+    # Build from git
+    pgenv build-git
+    
     # Use PostgreSQL version
     pgenv use 10.4
     
@@ -110,7 +113,8 @@ $ git pull
 *   curl - Used to download files
 *   sed, grep, cat, tar, sort, tr, uname - General Unix command line utilities
 *   patch - For patching versions that need patching
-*   make -  Builds PostgreSQL
+*   make - Builds PostgreSQL
+*   git - Used to download the current source tree
 
 Optional dependencies:
 
@@ -268,6 +272,38 @@ file. As an example
 
     $ PGENV_PATCH_INDEX=/src/my-patch-list.txt pgenv build 10.5
 
+
+
+### pgenv build-git
+
+This command fetches the current source tree from the official PostgreSQL git repository
+and builds it as special version `dev`. This is an option aimed to help developers
+to keep a version up-to-date with the current PostgreSQL source tree.
+
+Actually, the command is an *alias* for `build dev`, meaning that the following
+two commands are identical:
+    
+    $ pgenv build-git
+    $ pgenv build dev
+    
+The first time the command is called a source directory `dev` is created and the
+default branch is checked out. On a further execution, the command
+will fetch updates from the repository.
+
+It is possible to configure both the repository and the branch to fetch
+using the variables:
+- `PGENV_GIT_REPO` which defaults to `https://git.postgresql.org/git/postgresql.git`;
+- `PGENV_GIT_CHECKOUT_BRANCH` which if not set defaults to fetching the `master` branch, while
+  if set creates a tracking branch.
+
+The above variable have not been included in the configuration mechanism because they
+represent advanced tweaks. It is however possible to include them in the configuration file
+for this particular version (`.pgenv.dev.conf`) or in the global configuration file
+to drive the checkout and fetch process.
+
+Patching of the special `dev` version happens as for regular versions, but using the special
+`dev` version identifier, and therefore the patch index is searched with such string
+in place of a regular version number.
 
 
 ### pgenv remove

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Synopsis
     # Build PostgreSQL server
     pgenv build 10.4
     
-    # Build from git
-    pgenv build-git
+    # Build from official PostgreSQL repository (git)
+    pgenv build-dev
     
     # Use PostgreSQL version
     pgenv use 10.4
@@ -274,36 +274,34 @@ file. As an example
 
 
 
-### pgenv build-git
+### pgenv build-dev
 
 This command fetches the current source tree from the official PostgreSQL git repository
 and builds it as special version `dev`. This is an option aimed to help developers
 to keep a version up-to-date with the current PostgreSQL source tree.
 
-Actually, the command is an *alias* for `build dev`, meaning that the following
-two commands are identical:
+Actually, the command works as an *alias* for `build dev`, 
+meaning that the following two commands behave identically:
     
-    $ pgenv build-git
+    $ pgenv build-dev
     $ pgenv build dev
     
 The first time the command is called a source directory `dev` is created and the
-default branch is checked out. On a further execution, the command
+repository is cloned. On a further execution, the command
 will fetch updates from the repository.
 
-It is possible to configure both the repository and the branch to fetch
+It is possible to configure both the repository and the branch or checkout to fetch
 using the variables:
-- `PGENV_GIT_REPO` which defaults to `https://git.postgresql.org/git/postgresql.git`;
-- `PGENV_GIT_CHECKOUT_BRANCH` which if not set defaults to fetching the `master` branch, while
-  if set creates a tracking branch.
+- `PGENV_POSTGRESQL_REPOSITORY` which defaults to `https://git.postgresql.org/git/postgresql.git`;
+- `PGENV_POSTGRESQL_REPOSITORY_CHECKOUT` which if not set defaults to fetching the `master` branch, while if set creates a tracking branch.
 
 The above variable have not been included in the configuration mechanism because they
 represent advanced tweaks. It is however possible to include them in the configuration file
 for this particular version (`.pgenv.dev.conf`) or in the global configuration file
 to drive the checkout and fetch process.
 
-Patching of the special `dev` version happens as for regular versions, but using the special
-`dev` version identifier, and therefore the patch index is searched with such string
-in place of a regular version number.
+The whole `pgenv` workflow of a *regular* PostgreSQL 
+version appliees to the `dev` version as well.
 
 
 ### pgenv remove

--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ the following:
         stop       Stop the current PostgreSQL server
         restart    Restart the current PostgreSQL server
         build      Build a specific version of PostgreSQL
+        build-git  Build the development version ouf of git repository
         remove     Remove a specific version of PostgreSQL
         version    Show the current PostgreSQL version
         current    Same as 'version'

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -76,6 +76,7 @@ The pgenv commands are:
     stop       Stop the current PostgreSQL server
     restart    Restart the current PostgreSQL server
     build      Build a specific version of PostgreSQL
+    build-git  Build the development version ouf of git repository
     remove     Remove a specific version of PostgreSQL
     version    Show the current PostgreSQL version
     current    Same as 'version'

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -76,7 +76,7 @@ The pgenv commands are:
     stop       Stop the current PostgreSQL server
     restart    Restart the current PostgreSQL server
     build      Build a specific version of PostgreSQL
-    build-git  Build the development version ouf of git repository
+    build-dev  Build the development source tree pulled from the PostgreSQL repository
     remove     Remove a specific version of PostgreSQL
     version    Show the current PostgreSQL version
     current    Same as 'version'
@@ -182,8 +182,6 @@ pgenv_input_version_or_exit() {
     local version=$1
     local verbose=$2
     local hint=$3
-
-    echo "version $version"
 
     if [ -z "$version" ]; then
         if [ ! -z "$hint" ]; then
@@ -779,8 +777,8 @@ case $1 in
                 cd $BUILD_DIR
             else
                 cd $BUILD_DIR
-                pgenv_debug "Pulling $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_CHECKOUT"
-                $PGENV_GIT pull $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_CHECKOUT
+                pgenv_debug "Pulling $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_BRANCH"
+                $PGENV_GIT pull $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_BRANCH
             fi
 
         fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -150,6 +150,9 @@ pgenv_check_dependencies(){
     pgenv_detail_command "sort" $(which sort)
     pgenv_detail_command "tr" $(which tr)
 
+    # check for git (required by build-git)
+    pgenv_detail_command 'git' $(which git)
+
     # Go back to exiting on error.
     trap 'exit' ERR
     if [ ! -z "$verbose" ]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -810,7 +810,7 @@ case $1 in
         pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v] + [$PGENV_CONFIGURE_OPTS]"
         # need to keep a single string to pass to configure or
         # will get an 'invalid package'
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_OPTS --without-readline
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_OPTS 
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -151,8 +151,6 @@ pgenv_check_dependencies(){
     pgenv_detail_command "sort" $(which sort)
     pgenv_detail_command "tr" $(which tr)
 
-    # check for git (required by build-git)
-    pgenv_detail_command 'git' $(which git)
 
     # Go back to exiting on error.
     trap 'exit' ERR
@@ -769,14 +767,21 @@ case $1 in
                 PGENV_POSTGRESQL_REPOSITORY="https://git.postgresql.org/git/postgresql.git"
             fi
 
-            # do we need to do the initial repository clone?
-            if [ ! -d "$BUILD_DIR" ]; then
-                git clone $PGENV_POSTGRESQL_REPOSITORY  "$BUILD_DIR"
+            PGENV_GIT=$(which git)
+            if [ -z "$PGENV_GIT" ]; then
+                echo "Cannot found an usable version of git!"
+                exit 1
             fi
 
-            cd $BUILD_DIR
-            # do an update (not needed after the first checkout)
-            git pull $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_CHECKOUT
+            if [ ! -d "$BUILD_DIR" ]; then
+                pgenv_debug "Cloning repository $PGENV_POSTGRESQL_REPOSITORY into $BUILD_DIR"
+                $PGENV_GIT clone $PGENV_POSTGRESQL_REPOSITORY  "$BUILD_DIR"
+                cd $BUILD_DIR
+            else
+                cd $BUILD_DIR
+                pgenv_debug "Pulling $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_CHECKOUT"
+                $PGENV_GIT pull $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_CHECKOUT
+            fi
 
         fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -693,16 +693,16 @@ case $1 in
         exit
         ;;
 
-    build|build-git)
+    build|build-dev)
 
-        # in the case of 'build-git'
+        # in the case of 'build-dev'
         # the version defaults to 'dev'
         case $1 in
             build)     v=$2    ;;
-            build-git) v='dev'
-                       shift # remove the command
-                       ;;
+            build-dev) v='dev' ;;
         esac
+
+        shift # remove the command
 
         # sanity checks before building
         pgenv_input_version_or_exit "$v"
@@ -762,45 +762,23 @@ case $1 in
 
         else
             # here there is the build from git for 'dev'
-            BUILD_DIR=postgresql-dev
+            BUILD_DIR=postgresql-$v
 
             # initialize variables if not explicitly set
-            if [ -z "$PGENV_GIT_REPO" ]; then
-                PGENV_GIT_REPO="https://git.postgresql.org/git/postgresql.git"
+            if [ -z "$PGENV_POSTGRESQL_REPOSITORY" ]; then
+                PGENV_POSTGRESQL_REPOSITORY="https://git.postgresql.org/git/postgresql.git"
             fi
 
-            # if the user wants a specific branch, build the
-            # command line options
-            if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
-                PGENV_GIT_CHECKOUT="-b $PGENV_GIT_CHECKOUT_BRANCH --track origin/$PGENV_GIT_CHECKOUT_BRANCH"
-            else
-                # avoid tainting
-                PGENV_GIT_CHECKOUT=""
+            # do we need to do the initial repository clone?
+            if [ ! -d "$BUILD_DIR" ]; then
+                git clone $PGENV_POSTGRESQL_REPOSITORY  "$BUILD_DIR"
             fi
 
-            pgenv_debug "Checking out [$PGENV_GIT_REPO] @ [$PGENV_GIT_CHECKOUT]"
+            cd $BUILD_DIR
+            # do an update (not needed after the first checkout)
+            git pull $PGENV_POSTGRESQL_REPOSITORY $PGENV_POSTGRESQL_REPOSITORY_CHECKOUT
 
-            # download the sources
-            if [ -d "$BUILD_DIR" ]; then
-                # directory already existing, fetch new sources
-                cd "$BUILD_DIR"
-                git fetch $PGENV_GIT_REPO
-
-                if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
-                    git checkout $PGENV_GIT_CHECKOUT_BRANCH
-                fi
-            else
-                # first checkout
-                git clone $PGENV_GIT_REPO $PGENV_GIT_CHECKOUT "$BUILD_DIR"
-                cd "$BUILD_DIR"
-
-                if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
-                    git checkout $PGENV_GIT_CHECKOUT_BRANCH
-                fi
-            fi
         fi
-
-
 
         # patch the source tree if required
         pgenv_debug "Patching version $v"

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -780,10 +780,18 @@ case $1 in
                 # directory already existing, fetch new sources
                 cd dev
                 git fetch $PGENV_GIT_REPO
+
+                if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
+                    git checkout $PGENV_GIT_CHECKOUT_BRANCH
+                fi
             else
                 # first checkout
                 git clone $PGENV_GIT_REPO $PGENV_GIT_CHECKOUT dev
                 cd dev
+
+                if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
+                    git checkout $PGENV_GIT_CHECKOUT_BRANCH
+                fi
             fi
         fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -758,6 +758,7 @@ case $1 in
 
         else
             # here there is the build from git for 'dev'
+            BUILD_DIR=postgresql-dev
 
             # initialize variables if not explicitly set
             if [ -z "$PGENV_GIT_REPO" ]; then
@@ -776,9 +777,9 @@ case $1 in
             pgenv_debug "Checking out [$PGENV_GIT_REPO] @ [$PGENV_GIT_CHECKOUT]"
 
             # download the sources
-            if [ -d 'dev' ]; then
+            if [ -d "$BUILD_DIR" ]; then
                 # directory already existing, fetch new sources
-                cd dev
+                cd "$BUILD_DIR"
                 git fetch $PGENV_GIT_REPO
 
                 if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
@@ -786,8 +787,8 @@ case $1 in
                 fi
             else
                 # first checkout
-                git clone $PGENV_GIT_REPO $PGENV_GIT_CHECKOUT dev
-                cd dev
+                git clone $PGENV_GIT_REPO $PGENV_GIT_CHECKOUT "$BUILD_DIR"
+                cd "$BUILD_DIR"
 
                 if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
                     git checkout $PGENV_GIT_CHECKOUT_BRANCH
@@ -815,8 +816,6 @@ case $1 in
             cd contrib
             $PGENV_MAKE $PGENV_MAKE_OPTS
             $PGENV_MAKE install
-        elif [ "$v" = 'dev' ]; then
-            $PGENV_MAKE world $PGENV_MAKE_OPTS
         else
             # Yay, make world!
             $PGENV_MAKE world $PGENV_MAKE_OPTS

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -181,6 +181,8 @@ pgenv_input_version_or_exit() {
     local verbose=$2
     local hint=$3
 
+    echo "version $version"
+
     if [ -z "$version" ]; then
         if [ ! -z "$hint" ]; then
             # count the versions
@@ -214,6 +216,8 @@ pgenv_input_version_or_exit() {
         return # versions 9.5.4 or 10.1 and alike
     elif [[ $version =~ ^[1-9][1-9](beta|rc)[1-9]?$ ]]; then
         return # versions 11beta1 and alike
+    elif [ $version = 'dev' ]; then
+         return # building from git or alike
     else
         echo "Value \"$version\" does not appear to be a PostgreSQL valid version number"
         exit 1
@@ -685,8 +689,17 @@ case $1 in
         exit
         ;;
 
-    build)
-        v=$2
+    build|build-git)
+
+        # in the case of 'build-git'
+        # the version defaults to 'dev'
+        case $1 in
+            build)     v=$2    ;;
+            build-git) v='dev'
+                       shift # remove the command
+                       ;;
+        esac
+
         # sanity checks before building
         pgenv_input_version_or_exit "$v"
         pgenv_configuration_load $v
@@ -705,40 +718,76 @@ case $1 in
         fi
         cd src
 
-        # Download the source if wee don't already have it.
-        # WARNING: older PostgreSQL used .tar.gz instead of .tar.bz2,
-        # so if the version is behind 8 use the first format, otherwise
-        # try to get the most compressed archive
-        if [[ $v =~ ^[1-7]\. ]]; then
-            PG_TARBALL="postgresql-$v.tar.gz"
-            TAR_OPTS="zxf"
+
+        if [ "$v" != 'dev' ]; then
+            # Download the source if wee don't already have it.
+            # WARNING: older PostgreSQL used .tar.gz instead of .tar.bz2,
+            # so if the version is behind 8 use the first format, otherwise
+            # try to get the most compressed archive
+            if [[ $v =~ ^[1-7]\. ]]; then
+                PG_TARBALL="postgresql-$v.tar.gz"
+                TAR_OPTS="zxf"
+            else
+                PG_TARBALL="postgresql-$v.tar.bz2"
+                TAR_OPTS="jxf"
+            fi
+
+            if [ ! -f $PG_TARBALL ]; then
+                $PGENV_CURL -fLO ${PGENV_DOWNLOAD_ROOT}/v$v/${PG_TARBALL}
+            fi
+
+
+            # warn if no configuration was loaded
+            if [ -z "$PGENV_CONFIGURATION_FILE" ]; then
+                echo "WARNING: no configuration file found for version $v"
+                echo "HINT: if you wish to customize the build process please"
+                echo "stop the execution within 5 seconds (CTRL-c) and run "
+                echo "    pgenv config write $v && pgenv config edit $v"
+                echo "adjust 'configure' and 'make' options and flags and run again"
+                echo "    pgenv build $v"
+                echo
+                sleep 5
+            fi
+
+
+            # Unpack the source.
+            rm -rf "postgresql-$v"
+            $PGENV_TAR $TAR_OPTS $PG_TARBALL
+            cd postgresql-$v
+
+
         else
-            PG_TARBALL="postgresql-$v.tar.bz2"
-            TAR_OPTS="jxf"
+            # here there is the build from git for 'dev'
+
+            # initialize variables if not explicitly set
+            if [ -z "$PGENV_GIT_REPO" ]; then
+                PGENV_GIT_REPO="https://git.postgresql.org/git/postgresql.git"
+            fi
+
+            # if the user wants a specific branch, build the
+            # command line options
+            if [ ! -z "$PGENV_GIT_CHECKOUT_BRANCH" ]; then
+                PGENV_GIT_CHECKOUT="-b $PGENV_GIT_CHECKOUT_BRANCH --track origin/$PGENV_GIT_CHECKOUT_BRANCH"
+            else
+                # avoid tainting
+                PGENV_GIT_CHECKOUT=""
+            fi
+
+            pgenv_debug "Checking out [$PGENV_GIT_REPO] @ [$PGENV_GIT_CHECKOUT]"
+
+            # download the sources
+            if [ -d 'dev' ]; then
+                # directory already existing, fetch new sources
+                cd dev
+                git fetch $PGENV_GIT_REPO
+            else
+                # first checkout
+                git clone $PGENV_GIT_REPO $PGENV_GIT_CHECKOUT dev
+                cd dev
+            fi
         fi
 
-        if [ ! -f $PG_TARBALL ]; then
-            $PGENV_CURL -fLO ${PGENV_DOWNLOAD_ROOT}/v$v/${PG_TARBALL}
-        fi
 
-
-        # warn if no configuration was loaded
-        if [ -z "$PGENV_CONFIGURATION_FILE" ]; then
-            echo "WARNING: no configuration file found for version $v"
-            echo "HINT: if you wish to customize the build process please"
-            echo "stop the execution within 5 seconds (CTRL-c) and run "
-            echo "    pgenv config write $v && pgenv config edit $v"
-            echo "adjust 'configure' and 'make' options and flags and run again"
-            echo "    pgenv build $v"
-            echo
-            sleep 5
-        fi
-
-
-        # Unpack the source.
-        rm -rf "postgresql-$v"
-        $PGENV_TAR $TAR_OPTS $PG_TARBALL
-        cd postgresql-$v
 
         # patch the source tree if required
         pgenv_debug "Patching version $v"
@@ -748,7 +797,7 @@ case $1 in
         pgenv_debug "configure command line [--prefix=$PGENV_ROOT/pgsql-$v] + [$PGENV_CONFIGURE_OPTS]"
         # need to keep a single string to pass to configure or
         # will get an 'invalid package'
-        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_OPTS
+        ./configure --prefix=$PGENV_ROOT/pgsql-$v $PGENV_CONFIGURE_OPTS --without-readline
 
         # make and make install
         if [[ $v =~ ^[1-8]\. ]]; then
@@ -758,6 +807,8 @@ case $1 in
             cd contrib
             $PGENV_MAKE $PGENV_MAKE_OPTS
             $PGENV_MAKE install
+        elif [ "$v" = 'dev' ]; then
+            $PGENV_MAKE world $PGENV_MAKE_OPTS
         else
             # Yay, make world!
             $PGENV_MAKE world $PGENV_MAKE_OPTS


### PR DESCRIPTION
Implementation of 'build-git' command.

This command acts as an alias for 'build dev', that is introduces
the special version 'dev' to instrument the build process to download
the source tree via git instead of getting a tarball.

If the 'dev' version has never been created, than a complete checkout
is performed; otherwise a fetch is done.
The build process continues as usual, with patching, make, and etc.

At the end, the 'pgenv-dev' directory will be in place to indicate the
new version of PostgreSQL.

It is possible to configure the git process via two special variables, that
have not been introduced in the configuration mechanism because they
represent developer tweaks; they can be manually added in any case.
