### PR TITLE
Alias command implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,23 +139,71 @@ it if it's not already running.
     server started
     PostgreSQL 10.4 started
 
+If an alias has been defined for a specific PostgreSQL version, it is possible
+to specify the alias instead of the version number.
+
+
 ### pgenv versions
 
 Lists all PostgreSQL versions known to `pgenv`, and shows an asterisk next to
 the currently active version (if any). The first column reports versions
 available for use by `pgenv` and the second lists the subdirectory of
-`$PGENV_ROOT` in which the each version is installed:
+`$PGENV_ROOT` in which the each version is installed (in square backets).
+The third column lists aliases, if any are defined, for a particular
+version of PostgreSQL.
 
     $ pgenv versions
-          10.4      pgsql-10.4
-          11beta3   pgsql-11beta3
-          9.5.13    pgsql-9.5.13
-      *   9.6.9     pgsql-9.6.9
+          10.4      [pgsql-10.4]      stable java
+          11beta3   [pgsql-11beta3]   beta
+          9.5.13    [pgsql-9.5.13]    foo bar
+      *   9.6.9     [pgsql-9.6.9]
 
 In this example, versions `9.5.13`, `9.6.9`, `10.4`, and `11beta3` are
 available for use, and the `*` indicates that `9.6.10` is the currently active
-version. Each version is installed in a `pgsql-` subdirectory of
+version. Version `10.4` has two aliases, namely `stable` and `java`, while
+version `9.5.13` has aliases `foo` and `bar` and version `11beta3` has a single
+alias named `beta`. Aliases are *user defined* names that can be used
+to reference a PostgreSQL version, therefore naming `stable` or `10.4` is 
+the same.
+Each version is installed in a `pgsql-` subdirectory relative to
 `$PGENV_ROOT`.
+
+### pgenv alias
+
+The `alias` command allows users to define their own mnemonic names to 
+label a specific PostgreSQL version. Each command that requires a PostgreSQL
+version (e.g., `use`, `remove`) can accept an alias, that in turn
+is *translated** to the appropriate PostgreSQL version.
+
+Aliases can be defined only for currently installed PostgreSQL versions, and
+**must be unique**: it is not possible to define the same label for different
+PostgreSQL versions.
+
+Aliases are stored as symbolic links into the `alias` subdirectory of `PGENV_ROOT`.
+
+The `alias` command requires subcommands:
+- `add` adds one or more aliases to a PostgreSQL version. The PostgreSQL version
+must be already installed, and each alias label must be unique. If an alias already
+exists, the `add` command will skip such label and proceed to the next one (if any).
+As an example:
+
+     $ pgenv alias add 10.7 ten-stable my-favourite-version
+
+defines two different alias, `ten-stale` and `my-favourite-version` that are
+both aliases to version `10.7`. This means that it is possible to issue
+a command that accepts a PostgreSQL version specifying the alias:
+    
+    $ pgenv use 10.7
+    $ pgenv use ten-stable  # same as above
+
+
+- `remove` removes one or more aliases if defined. It is required to specify the
+alias (or aliases) to remove.
+
+   $ pgenv alias remove ten-stable
+   $ pgenv alias remove foo bar
+   
+   
 
 ### pgenv current
 
@@ -278,7 +326,11 @@ version. Use the `clear` command to clear the active version before removing it.
     $ pgenv remove 10.3
     PostgreSQL 10.3 removed
 
-The command removes the version, data directory, source code and configuration.
+The command removes the version, data directory, source code and configuration, 
+as well as all the aliases pointing to such version (if any).
+
+The command accepts an alias, if defined, to indicate the PostgreSQL installation
+to remove.
 
 ### pgenv start
 
@@ -386,6 +438,7 @@ the following:
         available  Show which versions can be downloaded
         check      Check all program dependencies
         config     View, edit, delete the program configuration
+        alias      Add, remove alias for installed PostgreSQL versions
 
     For full documentation, see: https://github.com/theory/pgenv#readme
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -14,6 +14,8 @@ fi
 cd $PGENV_ROOT
 # Always use an absolute path or configure could complain.
 PGENV_ROOT=$(pwd)
+PGENV_ALIASES_DIR=$PGENV_ROOT/aliases
+
 
 PGSQL=$PGENV_ROOT/pgsql
 PG_DATA=$PGSQL/data
@@ -46,9 +48,13 @@ pgenv_versions() {
     if [ -e "pgsql" ]; then
         local curr=$(readlink pgsql)
     fi
+
     local installed=0
     local flags=""
+    local aliases=""
+
     for dir in $( ls -d pgsql-* 2>/dev/null); do
+        aliases=""
         if [ "$dir" = "$curr" ]; then
             flags="  *"
         else
@@ -59,7 +65,18 @@ pgenv_versions() {
             PGENV_SED=$(which sed)
         fi
         local version=$( echo $dir | $PGENV_SED 's/^pgsql-//' )
-        printf "%s   %-6s    %s\n" "$flags" "$version" "$dir"
+
+        # search into all aliases to see if there is
+        # an alias that links to this current version
+        for current_alias in $PGENV_ALIASES_DIR/*; do
+            alias_for=$(readlink $current_alias)
+            if [ "$alias_for" = "$dir" ]; then
+                current_alias=$(basename $current_alias)
+                aliases+=" $current_alias"
+            fi
+        done
+
+        printf "%s   %-6s    [%s]   %s\n" "$flags" "$version" "$dir" "$aliases"
         installed=$(( installed + 1 ))
     done
 
@@ -87,6 +104,7 @@ The pgenv commands are:
     available  Show which versions can be downloaded
     check      Check all program dependencies
     config     View, edit, delete the program configuration
+    alias      Add, remove alias for installed PostgreSQL versions
 
 For full documentation, see: https://github.com/theory/pgenv#readme
 EOF
@@ -1010,6 +1028,70 @@ EOF
                 ;;
         esac
         exit
+        ;;
+
+    alias)
+        shift
+        # the command alias always wants at least one subcommand
+        ALIAS_ACTION=$1
+        shift
+
+        case $ALIAS_ACTION in
+            add)
+                # the very first argument to add is the version to alias
+                # and such version must be installed
+                v=$1
+                shift
+                pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
+                pgenv_installed_version_or_exit $v
+
+                # check there are aliases to create
+                if [ $# -eq 0 ]; then
+                    echo "You must specify which aliases to create for version $v"
+                    exit 1
+                fi
+
+                for alias_to_add in $*
+                do
+                    if [ ! -d $PGENV_ALIASES_DIR ]; then
+                        pgenv_debug "Creating directory for aliases [$PGENV_ALIASES_DIR]"
+                        mkdir -p $PGENV_ALIASES_DIR
+                    fi
+
+                    # do the alias
+                    alias_to_create=$PGENV_ALIASES_DIR/$alias_to_add
+                    if [ ! -h $alias_to_create ]; then
+                        ln -nsf pgsql-$v $alias_to_create
+                        pgenv_debug "Created alias $PGENV_ALIASES_DIR/$alias_to_add -> pgsql-$v"
+                    else
+                        echo "Alias $alias_to_add already exists, skipping"
+                    fi
+
+                done
+            ;;
+            remove)
+                if [ $# -eq 0 ]; then
+                    echo "Specify at least one alias to remove!"
+                    exit 1
+                fi
+
+                for alias_to_remove in $*
+                do
+                    pgenv_debug "Removing alias $alias_to_remove"
+                    to_remove=$PGENV_ALIASES_DIR/$alias_to_remove
+                    if [ -h $to_remove ]; then
+                        rm $to_remove
+                    else
+                        echo "Alias $alias_to_remove not found, skipping removal!"
+
+                    fi
+                done
+
+            ;;
+            *) echo "Please specify which action on command `alias` to perform"
+               exit 1
+               ;;
+        esac
         ;;
 
     *)

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -188,6 +188,31 @@ pgenv_check_dependencies(){
     fi
 }
 
+# A function to normalize the input for a specific PostgreSQL version.
+# This is a placeholder, so far it checks for an alias and returns the version
+# of the PostgreSQL to which the vesion corresponds, or the same version otherwise.
+#
+# In the future this can be used to perform some other
+# sanitize of the version number input.
+pgenv_input_version_normalize(){
+    local version=$1
+
+    # check if this is an alias
+    supposed_alias=$PGENV_ALIASES_DIR/$version
+    if [ -h $supposed_alias ]; then
+        version=$(readlink $supposed_alias)
+        version=$(basename $version)
+
+        if [ -z "$PGENV_SED" ]; then
+            PGENV_SED=$(which sed)
+        fi
+        version=$( echo $version | $PGENV_SED 's/^pgsql-//' )
+    fi
+
+    echo $version
+}
+
+
 # This function checks if its first argument is a valid PostgreSQL version
 # number, like "10.5" or "9.5.4". In case no version number is specified, or the
 # version number is invalid (e.g., "10", "0.9") the function aborts the script.
@@ -274,6 +299,20 @@ pgenv_current_version_number(){
     fi
     local v=$( readlink pgsql | $PGENV_SED 's/^pgsql-//' )
     echo $v
+}
+
+# Deletes all the aliases pointing to
+# a specific PostgreSQL version
+pgenv_aliases_delete(){
+    local v=$1
+
+    for current_alias in $PGENV_ALIASES_DIR/*; do
+        local alias_for=$( readlink $current_alias )
+        alias_for=$( basename $alias_for )
+        if [ "$alias_for" = "pgsql-$v" ]; then
+            rm $current_alias
+        fi
+    done
 }
 
 # Provides the configuration file name
@@ -651,7 +690,7 @@ pgenv_patch_source_tree() {
 
 case $1 in
     use)
-        v=$2
+        v=$( pgenv_input_version_normalize $2 )
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
         pgenv_installed_version_or_exit $v
         pgenv_configuration_load $v
@@ -668,7 +707,7 @@ case $1 in
             fi
 
             # Link the new instance.
-            ln -nsf pgsql-$2 pgsql
+            ln -nsf pgsql-$v pgsql
         fi
 
         # Init if needed.
@@ -809,6 +848,7 @@ case $1 in
 
     remove)
         v=$2
+        v=$( pgenv_input_version_normalize $v )
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
 
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then
@@ -823,6 +863,7 @@ case $1 in
         rm -fr src/postgresql-$v
         pgenv_configuration_delete $v  # remove this particular configuration
         pgenv_configuration_delete     # remove default configuration if no instances are left
+        pgenv_aliases_delete $v
         echo "PostgreSQL $v removed"
         exit
         ;;
@@ -1061,7 +1102,7 @@ EOF
                     # do the alias
                     alias_to_create=$PGENV_ALIASES_DIR/$alias_to_add
                     if [ ! -h $alias_to_create ]; then
-                        ln -nsf pgsql-$v $alias_to_create
+                        ln -nsf ../pgsql-$v $alias_to_create
                         pgenv_debug "Created alias $PGENV_ALIASES_DIR/$alias_to_add -> pgsql-$v"
                     else
                         echo "Alias $alias_to_add already exists, skipping"


### PR DESCRIPTION
Possible solution to #31 (part of the issue).
I propose this as a pull request because it requires a little testing and consideration.

The idea is to handle alias, i.e., other names, for installed postgresql verions. Each alias (i.e., name) is a link stored into the `alias` directory that points to the postgresql version.
All commands that accepts a version number (for installed versions) have been refactored to accept alias names also.
Documentation updated.