### PR TITLE
Implement a `psql` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,22 @@ It is possible to specify flags to pass to `pg_ctl(1)` when performing the
 `restart` action, setting the `PGENV_RESTART_OPTS` in the [configuration](#pgenv-config).
 
 
+### pgenv psql
+
+The `psql` command runs the `psql` client interface for the currently selected (i.e., `use`)
+version of PostgreSQL.
+This helps avoiding running system-wide `psql` of another version against PostgreSQL
+instances installed by `pgenv`.
+For instance:
+
+     $ pgenv psql -U luca template1
+    
+is equivalent to manually run
+
+    $ pgenv $PGENV_ROOT/pgsql/bin/psql -U luca template1
+
+All options and arguments will be passed untouched to the installed `psql` executable.
+
 ### pgenv available
 
 Shows all the versions of PostgreSQL available to download and build. Handy to

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -87,6 +87,7 @@ The pgenv commands are:
     available  Show which versions can be downloaded
     check      Check all program dependencies
     config     View, edit, delete the program configuration
+    psql       Runs the currently used psql executable
 
 For full documentation, see: https://github.com/theory/pgenv#readme
 EOF
@@ -1010,6 +1011,22 @@ EOF
                 ;;
         esac
         exit
+        ;;
+
+    psql)
+        pgenv_current_postgresql_or_exit
+
+        # execute the psql command for the currently used system
+        shift
+        psql_exe=$PGENV_ROOT/pgsql/bin/psql
+        if [ ! -x $psql_exe ]; then
+            echo "Cannot find executable for `psql` (looking for [$psql_exe])"
+            echo "Please ensure you have `use`d a PostgreSQL version"
+            exit 1
+        fi
+
+        pgenv_debug "Running [$psql_exe $@]"
+        $psql_exe $@
         ;;
 
     *)


### PR DESCRIPTION
Could be an implementation to avoid problems reported in issue #31.
The problem is that often there is a system-wide installed PostgreSQL
and/or client interfaces (`psql`). When using `psql` the user
gets the system wide that could be incompatible with the installed PostgreSQL
version from pgenv.
Using the `psql` command it is possible to run the version installed along-side
the PostgreSQL version `use`d by pgenv.