### PR TITLE
Add support for using a local PostgreSQL git repository for source archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ using a configuration file before the program launches the build.
 For a more detailed configuration, see the [`pgenv config`](#pgenv-config)
 command below.
 
+You can use a local PostgreSQL git repo instead of downloading tarballs
+for the build step by setting the external `$PGENV_LOCAL_POSTGRESQL_REPO`
+environment variable to the appropriate absolute path.
+
 ### Running scripts
 
 It is possible to run custom script when particular events happen. 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -880,7 +880,7 @@ case $1 in
         fi
         cd src
 
-        if [ -d $PGENV_LOCAL_POSTGRESQL_REPO ]; then
+        if [ ! -z "$PGENV_LOCAL_POSTGRESQL_REPO" ] && [ -d $PGENV_LOCAL_POSTGRESQL_REPO ]; then
             pgenv_debug "Using local postgresql repo: $PGENV_LOCAL_POSTGRESQL_REPO"
         else
             pgenv_debug "Downloading tarball"
@@ -926,7 +926,7 @@ EOF
 
         rm -rf "postgresql-$v"
 
-        if [ -d $PGENV_LOCAL_POSTGRESQL_REPO ]; then
+        if [ ! -z "$PGENV_LOCAL_POSTGRESQL_REPO" ] && [ -d $PGENV_LOCAL_POSTGRESQL_REPO ]; then
             pgenv_debug "Using local postgresql repo: $PGENV_LOCAL_POSTGRESQL_REPO"
 
             (cd $PGENV_LOCAL_POSTGRESQL_REPO &&

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -880,22 +880,27 @@ case $1 in
         fi
         cd src
 
-        # Download the source if wee don't already have it.
-        # WARNING: older PostgreSQL used .tar.gz instead of .tar.bz2,
-        # so if the version is behind 8 use the first format, otherwise
-        # try to get the most compressed archive
-        if [[ $v =~ ^[1-7]\. ]]; then
-            PG_TARBALL="postgresql-$v.tar.gz"
-            TAR_OPTS="zxf"
+        if [ -d $PGENV_LOCAL_POSTGRESQL_REPO ]; then
+            pgenv_debug "Using local postgresql repo: $PGENV_LOCAL_POSTGRESQL_REPO"
         else
-            PG_TARBALL="postgresql-$v.tar.bz2"
-            TAR_OPTS="jxf"
-        fi
+            pgenv_debug "Downloading tarball"
 
-        if [ ! -f $PG_TARBALL ]; then
-            $PGENV_CURL -fLO ${PGENV_DOWNLOAD_ROOT}/v$v/${PG_TARBALL}
-        fi
+            # Download the source if wee don't already have it.
+            # WARNING: older PostgreSQL used .tar.gz instead of .tar.bz2,
+            # so if the version is behind 8 use the first format, otherwise
+            # try to get the most compressed archive
+            if [[ $v =~ ^[1-7]\. ]]; then
+                PG_TARBALL="postgresql-$v.tar.gz"
+                TAR_OPTS="zxf"
+            else
+                PG_TARBALL="postgresql-$v.tar.bz2"
+                TAR_OPTS="jxf"
+            fi
 
+            if [ ! -f $PG_TARBALL ]; then
+                $PGENV_CURL -fLO ${PGENV_DOWNLOAD_ROOT}/v$v/${PG_TARBALL}
+            fi
+        fi
 
         # warn if no configuration was loaded
         if [ ! -z "PGENV_WARNINGS" ]; then
@@ -919,10 +924,30 @@ EOF
             fi
         fi
 
-
-        # Unpack the source.
         rm -rf "postgresql-$v"
-        $PGENV_TAR $TAR_OPTS $PG_TARBALL
+
+        if [ -d $PGENV_LOCAL_POSTGRESQL_REPO ]; then
+            pgenv_debug "Using local postgresql repo: $PGENV_LOCAL_POSTGRESQL_REPO"
+
+            (cd $PGENV_LOCAL_POSTGRESQL_REPO &&
+                 git fetch)
+            if [[ $v =~ ^[1-9]\. ]]; then
+                # version 1-9
+                tag=REL${v}
+            else
+                tag=REL_${v}
+            fi
+            tag=${tag^^}        # uppercase for rc, beta, etc
+            tag=${tag//./_}     # change dots to underscores
+
+            mkdir postgresql-$v
+            (cd $PGENV_LOCAL_POSTGRESQL_REPO &&
+                 git archive --format=tar $tag) | tar xp -C postgresql-$v
+        else
+            # Unpack the source.
+            $PGENV_TAR $TAR_OPTS $PG_TARBALL
+        fi
+            
         cd postgresql-$v
 
         # patch the source tree if required


### PR DESCRIPTION
While also involving git, unrelated to #26; more about eliminating the need to download the remote tarball, this just lets you configure to pull tagged archives from a local `git checkout` instead.