### PR TITLE
Remove which

### DIFF
--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1251,7 +1251,7 @@ EOF
 
             # tail is not in a PGENV_ variable, but should have been checked
             # via `pgenv check`
-            tail $* "$PGENV_LOG"
+            command tail $* "$PGENV_LOG"
             exit $?
         else
             # uhm.. no log is there, could it be the database

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1205,11 +1205,12 @@ EOF
                 pgenv_configuration_write "$v" ;;
             edit)
                 configuration_file=$( pgenv_configuration_file_name $v )
-                if [ ! -z "$EDITOR" ]; then
+                if [ ! -z "$EDITOR" ] && [ $(command -v $EDITOR ) ]; then
+                    pgenv_debug "Launching editor $EDITOR"
                     $EDITOR $configuration_file
                 else
                     cat <<EOF
-No EDITOR variable set!
+No EDITOR variable set (or executable)!
 You can either start manually your favourite
 editor to edit the configuration file
      $configuration_file

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -56,7 +56,7 @@ pgenv_versions() {
         fi
 
         if [ -z "$PGENV_SED" ]; then
-            PGENV_SED=$(which sed)
+            PGENV_SED=$(command -v sed)
         fi
         local version=$( echo $dir | $PGENV_SED 's/^pgsql-//' )
         printf "%s   %-6s    %s\n" "$flags" "$version" "$dir"
@@ -131,40 +131,40 @@ pgenv_check_dependencies(){
 
 
     if [ -z "$PGENV_MAKE" ]; then
-        PGENV_MAKE=$(which make)
+        PGENV_MAKE=$(command -v make)
         if [ -z "$PGENV_MAKE" ]; then
-            PGENV_MAKE=$(which gmake)
+            PGENV_MAKE=$(command -v gmake)
         fi
     fi
     pgenv_detail_command "make" $PGENV_MAKE
 
 
     if [ -z "$PGENV_CURL" ]; then
-        PGENV_CURL=$(which curl)
+        PGENV_CURL=$(command -v curl)
     fi
     pgenv_detail_command "curl" $PGENV_CURL
 
     if [ -z "$PGENV_PATCH" ]; then
-        PGENV_PATCH=$(which patch)
+        PGENV_PATCH=$(command -v patch)
     fi
     pgenv_detail_command "patch" $PGENV_PATCH
 
     if [ -z "$PGENV_TAR" ]; then
-        PGENV_TAR=$(which tar)
+        PGENV_TAR=$(command -v tar)
     fi
     pgenv_detail_command "tar" $PGENV_TAR
 
     if [ -z "$PGENV_SED" ]; then
-        PGENV_SED=$(which sed)
+        PGENV_SED=$(command -v sed)
     fi
     pgenv_detail_command "sed" $PGENV_SED
 
 
     # check for sort and tr and tail, but not place into
     # variables (do we need to push to that extent?)
-    pgenv_detail_command "sort" $(which sort)
-    pgenv_detail_command "tr" $(which tr)
-    pgenv_detail_command "tail" $(which tail)
+    pgenv_detail_command "sort" $(command -v sort)
+    pgenv_detail_command "tr" $(command -v tr)
+    pgenv_detail_command "tail" $(command -v tail)
 
     # Go back to exiting on error.
     trap 'exit' ERR
@@ -272,7 +272,7 @@ EOF
 pgenv_current_postgresql_version(){
     # find sed even without the configuration/dependencies
     if [ -z "$PGENV_SED" ]; then
-        PGENV_SED=$(which sed)
+        PGENV_SED=$(command -v sed)
     fi
     local v=$( readlink pgsql | $PGENV_SED 's/^pgsql-//' )
     echo $v


### PR DESCRIPTION
AFAIK Bash has a builtin `command` that can work as `which` in a faster way.
I've substituted all which calls with command, and the script works. I believe this does not imply any changes in the portability of the script, but I would like to get opinions on other Bash installations other than mine

```
 bash --version
bash --version
GNU bash, version 5.0.3(1)-release (x86_64-pc-linux-gnu)

```