### PR TITLE
Understand postgresql versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,13 @@ Command Reference
 
 Like `git`, the `pgenv` command delegates to subcommands based on its
 first argument. 
-Some commands require you to specify the PostgreSQL version to act against.
+
+Some commands require you to specify the PostgreSQL version to act on.
 You can specify the version the command applies to by either entering the
 PostgreSQL version number or by specifying any of the special keywords:
+
 - `current` or `version` to indicate the currently selected PostgreSQL version;
-- `oldest` to indicate the oldest installed version (exluding beta versions);
+- `earliest` to indicate the oldest installed version (exluding beta versions);
 - `newest` to indicate the newest installed version (exluding beta versions).
 
 The subcommands are:
@@ -196,6 +198,16 @@ it if it's not already running.
     waiting for server to start.... done
     server started
     PostgreSQL 10.4 started
+
+
+The `use` command supports the special keywords `earliest` and `latest`
+to respectively indicate the oldest PostgreSQL version installed and 
+the newest one. It is also possible to indicate a major version
+to narrow the scope of the special keywords. As an example:
+
+    $ pgenv use latest 10
+    
+will select the most recent PostgreSQL version of the 10 series installed.    
 
 ### pgenv versions
 
@@ -356,6 +368,16 @@ version. Use the `clear` command to clear the active version before removing it.
 
 The command removes the version, data directory, source code and configuration.
 
+The `remove` command supports the special keywords `earliest` and `latest`
+to respectively indicate the oldest PostgreSQL version installed and 
+the newest one. It is also possible to indicate a major version
+to narrow the scope of the special keywords. As an example:
+
+    $ pgenv remove latest 10
+    
+will remove the most recent PostgreSQL version of the 10 series installed.    
+
+
 ### pgenv start
 
 Starts the currently active version of PostgreSQL if it's not already running.
@@ -480,7 +502,7 @@ View, set, and delete configuration variables, both globally or for specific
 versions of PostgreSQL. Stores the configuration in Bash files, one for each
 version, as well as a default configuration. If pgenv cannot find a
 configuration variable in a version-specific configuration file, it will look
-in the default configuration. If it doesn't find it there, it tires to guess
+in the default configuration. If it doesn't find it there, it tries to guess
 the appropriate values, or falls back on its own defaults.
 
 The `config` command accepts the following subcommands:
@@ -495,7 +517,13 @@ special keyword:
 
 - `current` or `version` tells pgenv to use the currently active version of
   PostgreSQL
-- `default` tells pgenv to use the default configuration.
+- `default` tells pgenv to use the default configuration;
+- `earliest` and `latest` to indicate respectively the oldest or newest
+version of PostgreSQL installed. As in other commands, these two keywords
+can be combined with a PostgreSQL major version number to point to the
+configuration of the earliest/latest version within that major number.
+
+
 
 If no version is explicitly passed to any of the `config` subcommands, the
 program will work against the currently active version of PostgreSQL.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,15 @@ Command Reference
 -----------------
 
 Like `git`, the `pgenv` command delegates to subcommands based on its
-first argument. The subcommands are:
+first argument. 
+Some commands require you to specify the PostgreSQL version to act against.
+You can specify the version the command applies to by either entering the
+PostgreSQL version number or by specifying any of the special keywords:
+- `current` or `version` to indicate the currently selected PostgreSQL version;
+- `oldest` to indicate the oldest installed version (exluding beta versions);
+- `newest` to indicate the newest installed version (exluding beta versions).
+
+The subcommands are:
 
 ### pgenv use
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,24 @@ PostgreSQL version number or by specifying any of the special keywords:
 - `earliest` to indicate the oldest installed version (exluding beta versions);
 - `newest` to indicate the newest installed version (exluding beta versions).
 
+It is important to note that `earliest` and `latest` have nothing to do
+with the time you installed PostgreSQL by means of `pgenv`: they refer only
+to PostgreSQL *stable* versions. 
+To better clearify this, the following 
+snippet shows you which aliases point 
+to which versions in an example installation.
+
+
+     9.6.19                 <-- earliest (also earliest 9.6)
+     9.6.20      <-- latest 9.6
+     12.2        <-- earliest 12
+     12.4        <-- latest 12
+     13beta2
+     13.0                   <-- latest (also latest 13)
+
+
+
+
 The subcommands are:
 
 ### pgenv use

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -186,10 +186,15 @@ pgenv_check_dependencies(){
 # This function provides the specified version from an alias name.
 # WARNING: this does not include beta versions!!!
 #
-# Accepted parameters are either 'latest' or 'oldest' to select
+# Accepted parameters are either 'latest' or 'earliest' to select
 # the latest stable version installed or the oldest one.
+# If the option second argument is specified, it must be a "filter"
+# to the version to search for, usually the major version number.
+# So for example passing '9.6' as second argument will restrict
+# the search into all the installed '9.6.x' versions.
 pgenv_find_version_on_disk(){
     local search_for=$1
+    local filter=$2
     local brand
     local year
     local selected
@@ -202,7 +207,7 @@ pgenv_find_version_on_disk(){
         PGENV_SED=$(which sed)
     fi
 
-    for version in $( ls -d pgsql-* 2>/dev/null | $PGENV_SED 's/pgsql-//' ); do
+    for version in $( ls -d pgsql-${filter}* 2>/dev/null | $PGENV_SED 's/pgsql-//' ); do
         pgenv_debug "Version $version"
         brand=$( echo $version | $PGENV_SED 's/\([[:digit:]]\{1,2\}\).*/\1/' )
         year=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.\([[:digit:]]\{1,2\}\).*/\1/' )
@@ -218,7 +223,7 @@ pgenv_find_version_on_disk(){
                     selected=$version
                 fi
                 ;;
-            oldest)
+            earliest)
                 if [ -z "$selected_value" ] || [ $selected_value -gt $current_version ]; then
                     selected_value=$current_version
                     selected=$version
@@ -227,7 +232,7 @@ pgenv_find_version_on_disk(){
         esac
     done
 
-    pgenv_debug "Version selected for [$search_for] = $selected"
+    pgenv_debug "Version selected for [$search_for $filter] = $selected"
     echo $selected
 }
 
@@ -240,9 +245,14 @@ pgenv_find_version_on_disk(){
 #
 # - with $2 = 13.0 will return it (13.0);
 # - with $2 = "current" will return the current version in use (if any)
-# - with $2 = "oldest" will return the oldest version installed
+# - with $2 = "earliest" will return the oldest version installed
+#
+# In the case an optional second parameter is passed, it will be used
+# as a filter for 'latest' and 'earliest'. For example 'latest' '13'
+# will search for the very latest version available between the '13.x' series.
 pgenv_guess_postgresql_version() {
     local v=$1
+    local filter=$2
 
     case "$v" in
         current|version)
@@ -254,9 +264,9 @@ pgenv_guess_postgresql_version() {
             # for specifying the 'default configuration'
             v=""
             ;;
-        latest|oldest)
+        latest|earliest)
             # must guess!
-            v=$( pgenv_find_version_on_disk "$v" )
+            v=$( pgenv_find_version_on_disk "$v" "$filter" )
     esac
 
     pgenv_debug "Guessed PostgreSQL version is [$v]"
@@ -873,7 +883,7 @@ pgenv_patch_source_tree() {
 
 case $1 in
     use)
-        v=$( pgenv_guess_postgresql_version $2 )
+        v=$( pgenv_guess_postgresql_version $2 $3)
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
         pgenv_installed_version_or_exit $v
         pgenv_configuration_load $v
@@ -1091,7 +1101,7 @@ EOF
         ;;
 
     remove)
-        v=$( pgenv_guess_postgresql_version $v )
+        v=$( pgenv_guess_postgresql_version "$2" "$3" )
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
 
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then
@@ -1255,7 +1265,7 @@ EOF
         action=$2
 
         # understand the version the user wants to configure
-        v=$( pgenv_guess_postgresql_version $3 )
+        v=$( pgenv_guess_postgresql_version $3 $4 )
         # get the currently in use if none specified
         if [ -z "$v" ]; then
             pgenv_exit_if_no_postgresql_in_use
@@ -1335,12 +1345,6 @@ EOF
         fi
         ;;
 
-
-    test)
-        pgenv_guess_postgresql_version "latest"
-        pgenv_guess_postgresql_version "oldest"
-        pgenv_guess_postgresql_version "13.5"
-        ;;
 
     *)
         if [ $# -gt 0 ]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1242,29 +1242,16 @@ EOF
 
     config|configuration)
         action=$2
-        v=$3
 
-        # which version does the user wants?
-        case "$v" in
-            version|current)
-                v=$( pgenv_current_postgresql_version )
-                title='PostgreSQL currently in use'
-                ;;
-            default)
-                v=''
-                title='Default configuration'
-                ;;
-            *)
-                # get the currently in use if none specified
-                if [ -z "$v" ]; then
-                    pgenv_exit_if_no_postgresql_in_use
-                    v=$( pgenv_current_postgresql_version )
-                fi
+        # understand the version the user wants to configure
+        v=$( pgenv_guess_postgresql_version $3 )
+        # get the currently in use if none specified
+        if [ -z "$v" ]; then
+            pgenv_exit_if_no_postgresql_in_use
+            v=$( pgenv_current_postgresql_version )
+        fi
 
-                title="PostgreSQL $v"
-                ;;
-        esac
-
+        title="PostgreSQL version $v"
 
         case $action in
             show)

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -881,7 +881,7 @@ case $1 in
             fi
 
             # Link the new instance.
-            ln -nsf pgsql-$2 pgsql
+            ln -nsf pgsql-$v pgsql
         fi
 
         # Init if needed.

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -213,7 +213,9 @@ pgenv_find_version_on_disk(){
         year=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.\([[:digit:]]\{1,2\}\).*/\1/' )
         patch=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.[[:digit:]]\{1,2\}\.\{0,1\}\([[:digit:]]\{0,2\}\).*/\1/' )
 
-        current_version="${brand}${year}${patch}"
+        # to avoid that version less than 10 confuses the match, let's
+        # multiply the brand version by 1000
+        current_version=$(( ( brand * 1000 ) + ( year * 100 ) + patch ))
         pgenv_debug "Found version [$current_version]"
 
         case "$search_for" in

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -887,7 +887,8 @@ case $1 in
         else
             # Shut down existing running instance.
             if [ -e "pgsql" ]; then
-                pgenv_stop_or_restart_instance 'stop' "$v"
+                stopping_version=$( pgenv_current_postgresql_version )
+                pgenv_stop_or_restart_instance 'stop' "$stopping_version"
             fi
 
             # Link the new instance.

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1080,7 +1080,7 @@ EOF
         ;;
 
     remove)
-        v=$2
+        v=$( pgenv_guess_postgresql_version $v )
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
 
         if [ "`readlink pgsql`" = "pgsql-$v" ]; then

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -231,6 +231,16 @@ pgenv_find_version_on_disk(){
     echo $selected
 }
 
+
+# Guesses the selected PostgreSQL version to use.
+# The idea is that every time a command needs a PostgreSQL version number
+# this function should be called.
+# As an example:
+# v=$( pgenv_guess_postgresql_version $2 )
+#
+# - with $2 = 13.0 will return it (13.0);
+# - with $2 = "current" will return the current version in use (if any)
+# - with $2 = "oldest" will return the oldest version installed
 pgenv_guess_postgresql_version() {
     local v=$1
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -208,6 +208,11 @@ pgenv_find_version_on_disk(){
     fi
 
     for version in $( ls -d pgsql-${filter}* 2>/dev/null | $PGENV_SED 's/pgsql-//' ); do
+        # skip beta versions
+        if [[ $version =~ ^[1-9][1-9](beta|rc)[1-9]?$ ]]; then
+            continue
+        fi
+
         pgenv_debug "Version $version"
         brand=$( echo $version | $PGENV_SED 's/\([[:digit:]]\{1,2\}\).*/\1/' )
         year=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.\([[:digit:]]\{1,2\}\).*/\1/' )

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -183,6 +183,77 @@ pgenv_check_dependencies(){
     fi
 }
 
+# This function provides the specified version from an alias name.
+# WARNING: this does not include beta versions!!!
+#
+# Accepted parameters are either 'latest' or 'oldest' to select
+# the latest stable version installed or the oldest one.
+pgenv_find_version_on_disk(){
+    local search_for=$1
+    local brand
+    local year
+    local selected
+    local patch
+    local current_version
+    local selected_value
+
+    # find sed even without the configuration/dependencies
+    if [ -z "$PGENV_SED" ]; then
+        PGENV_SED=$(which sed)
+    fi
+
+    for version in $( ls -d pgsql-* 2>/dev/null | $PGENV_SED 's/pgsql-//' ); do
+        pgenv_debug "Version $version"
+        brand=$( echo $version | $PGENV_SED 's/\([[:digit:]]\{1,2\}\).*/\1/' )
+        year=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.\([[:digit:]]\{1,2\}\).*/\1/' )
+        patch=$(  echo $version | $PGENV_SED 's/[[:digit:]]\{1,2\}\.[[:digit:]]\{1,2\}\.\{0,1\}\([[:digit:]]\{0,2\}\).*/\1/' )
+
+        current_version="${brand}${year}${patch}"
+        pgenv_debug "Found version [$current_version]"
+
+        case "$search_for" in
+            latest)
+                if [ -z "$selected_value" ] || [ $selected_value -lt $current_version ]; then
+                    selected_value=$current_version
+                    selected=$version
+                fi
+                ;;
+            oldest)
+                if [ -z "$selected_value" ] || [ $selected_value -gt $current_version ]; then
+                    selected_value=$current_version
+                    selected=$version
+                fi
+                ;;
+        esac
+    done
+
+    pgenv_debug "Version selected for [$search_for] = $selected"
+    echo $selected
+}
+
+pgenv_guess_postgresql_version() {
+    local v=$1
+
+    case "$v" in
+        current|version)
+            # current version is the one that has been selected by `use`
+            v=$( pgenv_current_postgresql_version )
+            ;;
+        default)
+            # there is no default version, this is useful only
+            # for specifying the 'default configuration'
+            v=""
+            ;;
+        latest|oldest)
+            # must guess!
+            v=$( pgenv_find_version_on_disk "$v" )
+    esac
+
+    pgenv_debug "Guessed PostgreSQL version is [$v]"
+    echo "$v"
+}
+
+
 # This function checks if its first argument is a valid PostgreSQL version
 # number, like "10.5" or "9.5.4". In case no version number is specified, or the
 # version number is invalid (e.g., "10", "0.9") the function aborts the script.
@@ -792,7 +863,7 @@ pgenv_patch_source_tree() {
 
 case $1 in
     use)
-        v=$2
+        v=$( pgenv_guess_postgresql_version $2 )
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
         pgenv_installed_version_or_exit $v
         pgenv_configuration_load $v
@@ -1264,6 +1335,13 @@ and it is logging to
 EOF
             exit 1
         fi
+        ;;
+
+
+    test)
+        pgenv_guess_postgresql_version "latest"
+        pgenv_guess_postgresql_version "oldest"
+        pgenv_guess_postgresql_version "13.5"
         ;;
 
     *)


### PR DESCRIPTION
I'm not sure if this effort is worth the time, and that is why I'm presenting as pull request.
The idea is to specify PostgreSQL versions as spelled out for every command that applies to _installed_ versions. So far it does support only `latest`, `current`, `default` and `oldest`.

As an example:
```
% pgenv versions   
      12.4      pgsql-12.4
      13.0      pgsql-13.0

% pgenv use latest
PostgreSQL 13.0 started
Logging to /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log

% pgenv use oldest
PostgreSQL 12.4 started
Logging to /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log
```