### PR TITLE
Modify warning conditions and fix typos

### DIFF
--- a/bin/pgenv
+++ b/bin/pgenv
@@ -698,6 +698,13 @@ EOF
         if [ "$p" -ef "$executables" ]; then
             path_ok=1
             break
+        elif [ "$p" == "$executables" ]; then
+            # PATH contains the entry
+            # but the entry itself does not exist,
+            # so no PostgreSQL instances are in use.
+            # By the time an instance comes in use
+            # everything should be fine, so ignore this.
+            return
         fi
     done
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -662,9 +662,36 @@ pgenv_warning_path(){
     local executables_wanted=0
     local executables="$PGENV_ROOT/pgsql/bin"
 
+    # Test if pgsql is a link and not manually created
+    # This should be a link only managed by this script
+    if [ -e "$PGENV_ROOT/pgsql" ] && ! [ -h "$PGENV_ROOT/pgsql" ]; then
+        cat <<EOF >&2
+
+WARNING:
+   Database working directory
+
+        $PGENV_ROOT/pgsql
+
+   should not be created manually.
+
+HINT:
+   Make a backup of it if this is an existing database
+   directory and remove it, then let this script manage
+   it automatically by building an instance of a PostgreSQL:
+
+        pgenv build <version>
+
+   and then using it:
+
+        pgenv use <version>
+
+EOF
+    return
+    fi
+
     IFS=':'
 
-    # Thest if PATH contains at least one entry
+    # Test if PATH contains at least one entry
     # with the executables dir
     for p in $PATH
     do
@@ -680,7 +707,7 @@ pgenv_warning_path(){
         cat <<EOF >&2
 
 WARNING:
-  your PATH enrvironemnt variable does not seem to include
+  Your PATH enrvironemnt variable does not seem to include
 
        $executables
 
@@ -688,7 +715,7 @@ WARNING:
   selected PostgreSQL binaries.
 
 HINT:
-  adjust your PATH variable to include
+  Adjust your PATH variable to include
 
   $executables
 
@@ -717,12 +744,12 @@ EOF
         cat <<EOF >&2
 
 WARNING:
-   your PATH environment variable has some PostgreSQL executable
+   Your PATH environment variable has some PostgreSQL executable
    preprended to the currently in-use instance, so you may
    end up using the wrong executables against the selected cluster.
 
 HINT:
-   prepend the following PATH entry in your environment setting
+   Prepend the following PATH entry in your environment setting
 
    $executables
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1432,7 +1432,7 @@ EOF
                     pgenv_debug "Launching editor $EDITOR"
                     $EDITOR $configuration_file
                 else
-                    cat <<EOF
+                    cat <<EOF >&2
 No EDITOR variable set (or executable)!
 You can either start manually your favourite
 editor to edit the configuration file
@@ -1448,7 +1448,19 @@ EOF
                 pgenv_configuration_delete "$v" ;;
             *)
                 if [ -z "$action" ]; then
-                    echo "You need to specify a \`config\` action to perform"
+                    cat <<EOF >&2
+You need to specify one of the following \`config\` actions to perform:
+
+    show
+    write
+    edit
+    delete
+
+For instance:
+
+    pgenv config show <version>
+
+EOF
                 else
                     echo "Configuration action \`$action\` not supported"
                 fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -658,7 +658,7 @@ pgenv_warning_path(){
 
     local old_ifs=$IFS
     local path_ok=0
-    local path_prepended=0
+    local path_prepend=0
     local executables_wanted=0
     local executables="$PGENV_ROOT/pgsql/bin"
 
@@ -726,7 +726,7 @@ HINT:
 
    $executables
 
-   like for instance
+   for instance
 
    export PATH=$executables:\$PATH
 


### PR DESCRIPTION
I fixed a few typos and changed the conditions in pgenv_warning_path() function.