### PR TITLE
Delete default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,12 +494,13 @@ Shows all the versions of PostgreSQL available to download and build. Handy to
 help you finding a version to pass to the `build` command. Note that the
 `available` command produces copious output.
 
-```
-$ pgenv available
-...
+``` sh
+pgenv available
+
             Available PostgreSQL Versions
 ========================================================
-
+                  ...
+ 
                     PostgreSQL 9.6
     ------------------------------------------------
     9.6.0   9.6.1   9.6.2   9.6.3   9.6.4   9.6.5
@@ -511,7 +512,24 @@ $ pgenv available
 
                     PostgreSQL 11
     ------------------------------------------------
-    11beta1  11beta2  11beta3
+     11.0    11.1    11.2    11.3    11.4    11.5   
+     11.6    11.7    11.8    11.9    11.10   11.11  
+     11.12   11.13  
+
+                     PostgreSQL 12
+    ------------------------------------------------
+     12.0    12.1    12.2    12.3    12.4    12.5   
+     12.6    12.7    12.8   
+
+                     PostgreSQL 13
+    ------------------------------------------------
+     13.0    13.1    13.2    13.3    13.4   
+
+                     PostgreSQL 14
+    ------------------------------------------------
+     14beta1  14beta2  14beta3  14rc1   14.0   
+
+     
 ```
 
 The versions are organized and sorted by major release number. Any listed
@@ -590,19 +608,14 @@ appropriate values, or falls back on its own defaults.
 
 The `config` command accepts the following subcommands:
 
-<<<<<<< HEAD
+
 - `show` prints the current or specified version configuration
 - `init` produces a configuration file from scratch, with default settings
 - `write` store the specified version configuration
-- `edit` opens the current or specified version configuration in an editor (Using $EDITOR, e.g: export EDITOR=/usr/bin/vim)
+- `edit` opens the current or specified version configuration file in your favourite text editor 
+        (Using `$EDITOR`, e.g: `export EDITOR=/usr/bin/emacs`)
 - `delete` removes the specified configuration
-=======
--   `show` prints the current or specified version configuration
--   `write` store the current or specified version configuration
--   `edit` opens the current or specified version configuration in an editor
-    (Using $EDITOR, e.g: export `EDITOR=/usr/bin/vim`)
--   `delete` removes the specified configuration
->>>>>>> e7e289cea8c3a232d51e06af93fc798d01c8a36b
+ 
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a
 special keyword:

--- a/README.md
+++ b/README.md
@@ -554,11 +554,10 @@ the appropriate values, or falls back on its own defaults.
 The `config` command accepts the following subcommands:
 
 - `show` prints the current or specified version configuration
-- `init` produces a blank configuration file, with standard settings
+- `init` produces a configuration file from scratch, with default settings
 - `write` store the specified version configuration
 - `edit` opens the current or specified version configuration in an editor (Using $EDITOR, e.g: export EDITOR=/usr/bin/vim)
 - `delete` removes the specified configuration
-- `nuke` similar to `delete`, that removes also the default configuration if none is specified
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a
 special keyword:
@@ -628,7 +627,10 @@ to use the `init` or `write` commands. If no prior default configuration exists,
 the commands do the same, that is they create a from-scratch configuration file.
 If a default configuration exists, the `write` command will "clone" such configuration
 in a PostgreSQL version specific configuration file, while `init` will 
-create a blank configuration file.
+create a configuration file with default settings.
+After a configuration file has been created by `init`, the `write` or `edit`
+commands must be used against it, that means an existing configuration file
+cannot be `init`ed more than once.
 
    $ pgenv config write 10.5
    pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
@@ -654,8 +656,7 @@ Use the `delete` subcommand to delete a configuration:
 The `delete` subcommand will not attempt to delete the default configuration
 file, since it can be shared among different PostgreSQL versions.
 However, if it is explicitly specified `default` as the version to delete
-(i.e., `config delete default`) or the `config nuke` command is run, the
-default configuration file will be deleted.
+(i.e., `config delete default`), the default configuration file will be deleted.
 
          
 
@@ -664,13 +665,7 @@ copy. The `pgenv remove` command also deletes any configuration for the
 removed version.
 
 
-The `nuke` subcommand behaves as `delete`, but allows for deletion of the default
-configuration file even if it is not explicitly specified as argument. In other
-words, the two following commands are the same
-
-    $ pgenv config delete default
-    $ pgenv config nuke
-
+     
 Please note that since commit [5839e721](https://github.com/theory/pgenv/commit/5839e721d43c9eae8b4a0d61ba78996c220a4da0) 
 the file name of the default configuration file has changed. In the case you want to convert your 
 default configuration file, please issue a rename like the following

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ command won't stop it, but will initialize its data directory and starts it if
 it's not already running.
 
 ```
-$ pgenv use 10.4
+pgenv use 10.4
 waiting for server to shut down.... done
 server stopped
 waiting for server to start.... done
@@ -242,7 +242,7 @@ available for use by `pgenv` and the second lists the subdirectory of
 `$PGENV_ROOT` in which the each version is installed:
 
 ```
-$ pgenv versions
+pgenv versions
       10.4      pgsql-10.4
       11beta3   pgsql-11beta3
       9.5.13    pgsql-9.5.13
@@ -258,14 +258,14 @@ Each version is installed in a `pgsql-` subdirectory of `$PGENV_ROOT`.
 Displays the currently active PostgreSQL version.
 
 ```
-$ pgenv current
+pgenv current
 10.4
 ```
 
 Please note that `version` is a command synonym for version:
 
 ```
-$ pgenv version
+pgenv version
 10.4
 ```
 
@@ -275,7 +275,7 @@ Clears the currently active version of PostgreSQL. If the current version is
 running, `clear` will stop it before clearing it.
 
 ```
-$ pgenv clear
+pgenv clear
 waiting for server to shut down.... done
 server stopped
 PostgreSQL stopped
@@ -291,7 +291,7 @@ version is already built, it will not be rebuilt; use `clear` to remove an
 existing version before building it again.
 
 ```
-$ pgenv build 10.3
+pgenv build 10.3
 # [Curl, configure, and make output elided]
 PostgreSQL 10.3 built
 ```
@@ -302,7 +302,7 @@ warning is shown to the user to remind she can edit a configuration file and
 start over the build process:
 
 ```sh
-$ pgenv build 10.3
+pgenv build 10.3
   ...
 WARNING: no configuration file found for version 10.3
 HINT: if you wish to customize the build process please
@@ -428,7 +428,7 @@ Removes the specified version of PostgreSQL unless it is the currently-active
 version. Use the `clear` command to clear the active version before removing it.
 
 ```
-$ pgenv remove 10.3
+pgenv remove 10.3
 PostgreSQL 10.3 removed
 ```
 
@@ -440,7 +440,7 @@ one. It is also possible to indicate a major version to narrow the scope of the
 special keywords. As an example:
 
 ```
-$ pgenv remove latest 10
+pgenv remove latest 10
 ```
     
 will remove the most recent PostgreSQL version of the 10 series installed.    
@@ -451,7 +451,7 @@ Starts the currently active version of PostgreSQL if it's not already running.
 Initializes the data directory if none exists.
 
 ```
-$ pgenv start
+pgenv start
 PostgreSQL started
 ```
     
@@ -465,7 +465,7 @@ directory, nor the log file.
 Stops the currently active version of PostgreSQL.
 
 ```
-$ pgenv stop
+pgenv stop
 PostgreSQL 10.5 stopped
 ```
 
@@ -479,7 +479,7 @@ Restarts the currently active version of PostgreSQL, or starts it if it's not
 already running.
 
 ```
-$ pgenv restart
+pgenv restart
 PostgreSQL 10.1 restarted
 Logging to pgsql/data/server.log
 ```
@@ -539,7 +539,7 @@ To limit the list to versions for specific major releases, pass them to
 `available`. For example, to list only the `9.6` and `10` available versions:
 
 ```
-$ pgenv available 10 9.6
+pgenv available 10 9.6
             Available PostgreSQL Versions
 ========================================================
 
@@ -565,7 +565,7 @@ Outputs a brief usage statement and summary of available commands, like the
 following:
 
 ```
-$ pgenv help
+pgenv help
 Usage: pgenv <command> [<args>]
 
 The pgenv commands are:
@@ -635,7 +635,7 @@ program will work against the currently active version of PostgreSQL.
 In order to start with a default configuration, use the `write` subcommand:
 
 ```
-$ pgenv config write default
+pgenv config write default
 pgenv configuration file ~/.pgenv/.pgenv.default.conf written
 ```
 
@@ -702,7 +702,7 @@ been created.
 Use the `edit` subcommand to edit a configuration file in your favorite editor:
 
 ```
-$ pgenv config edit 10.5
+pgenv config edit 10.5
 <output omitted>
 ```
 
@@ -724,7 +724,7 @@ However, if it is explicitly specified `default` as the version to delete
          
 
 ```
-$ pgenv config delete
+pgenv config delete
 Cannot delete default configuration while version configurations exist
 To remove it anyway, delete ~/.pgenv/.pgenv.default.conf.
 ```
@@ -751,7 +751,7 @@ don't have to worry about the exact log location. The log is dumped using the
 `tail`. As an example:
 
 ```
-$ pgenv log     
+pgenv log     
 Dumping the content of /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 
 2020-08-28 19:04:44.199 CEST [10702] LOG:  could not bind IPv4 address "127.0.0.1": Address already in use
@@ -775,7 +775,7 @@ tail /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log
 It is possible to pass arguments to `tail` as command line flags:
 
 ```
-$ pgenv log -n 2
+pgenv log -n 2
 Dumping the content of /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 
 2020-08-28 19:09:09.045 CEST [11868] LOG:  database system was shut down at 2020-08-28 12:57:33 CEST

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installation
 1.  Check out pgenv into `~/.pgenv`.
 
     ``` sh
-    $ git clone https://github.com/theory/pgenv.git ~/.pgenv
+    git clone https://github.com/theory/pgenv.git ~/.pgenv
     ```
 
 2.  Add `~/.pgenv/bin` and `~/.pgenv/pgsql/bin` to your `$PATH` for access to
@@ -60,7 +60,7 @@ Installation
     PostgreSQL:
    
     ``` sh
-    $ echo 'export PATH="$HOME/.pgenv/bin:$HOME/.pgenv/pgsql/bin:$PATH"' >> ~/.bash_profile
+    echo 'export PATH="$HOME/.pgenv/bin:$HOME/.pgenv/pgsql/bin:$PATH"' >> ~/.bash_profile
     ```
 
     **Ubuntu note**: Modify your `~/.profile` instead of `~/.bash_profile`.
@@ -71,13 +71,13 @@ Installation
     can now begin using pgenv.
 
     ``` sh
-    $ exec $SHELL -l
+    exec $SHELL -l
     ```
 
 4.  Build a version of PostgreSQL:
 
     ``` sh
-    $ pgenv build 10.4
+    pgenv build 10.4
     ```
 
 ### Configuration
@@ -156,8 +156,8 @@ You can upgrade your installation to the cutting-edge version at any time
 with a simple `git pull`.
 
 ``` sh
-cd ~/.pgenv
-git pull
+$ cd ~/.pgenv
+$ git pull
 ```
 
 ### Dependencies
@@ -214,7 +214,7 @@ stopped before switching. If the specified version is already in use, the `use`
 command won't stop it, but will initialize its data directory and starts it if
 it's not already running.
 
-``` sh
+```
 $ pgenv use 10.4
 waiting for server to shut down.... done
 server stopped
@@ -229,7 +229,7 @@ one. It is also possible to indicate a major version to narrow the scope of the
 special keywords. As an example:
 
 ``` sh
-$ pgenv use latest 10
+pgenv use latest 10
 ```
 
 will select the most recent PostgreSQL version of the 10 series installed.    
@@ -241,7 +241,7 @@ the currently active version (if any). The first column reports versions
 available for use by `pgenv` and the second lists the subdirectory of
 `$PGENV_ROOT` in which the each version is installed:
 
-``` sh
+```
 $ pgenv versions
       10.4      pgsql-10.4
       11beta3   pgsql-11beta3
@@ -257,14 +257,14 @@ Each version is installed in a `pgsql-` subdirectory of `$PGENV_ROOT`.
 
 Displays the currently active PostgreSQL version.
 
-``` sh
+```
 $ pgenv current
 10.4
 ```
 
 Please note that `version` is a command synonym for version:
 
-``` sh
+```
 $ pgenv version
 10.4
 ```
@@ -274,7 +274,7 @@ $ pgenv version
 Clears the currently active version of PostgreSQL. If the current version is
 running, `clear` will stop it before clearing it.
 
-``` sh
+```
 $ pgenv clear
 waiting for server to shut down.... done
 server stopped
@@ -290,7 +290,7 @@ process to patch the source tree, see the section on patching later on. If the
 version is already built, it will not be rebuilt; use `clear` to remove an
 existing version before building it again.
 
-``` sh
+```
 $ pgenv build 10.3
 # [Curl, configure, and make output elided]
 PostgreSQL 10.3 built
@@ -301,7 +301,7 @@ system does not find a configuration file when the `build` is executed, a
 warning is shown to the user to remind she can edit a configuration file and
 start over the build process:
 
-```sh
+```
 $ pgenv build 10.3
   ...
 WARNING: no configuration file found for version 10.3
@@ -342,8 +342,8 @@ $ pgenv build 10.5
 In the case you need to specify a particular variable, such as the Perl
 interpreter, pass it on the command line at the time of build:
 
-``` sh
-$ PERL=/usr/local/my-fancy-perl pgenv build 10.5
+``` 
+PERL=/usr/local/my-fancy-perl pgenv build 10.5
 ```
 
 #### Patching
@@ -428,7 +428,7 @@ In the case a specific version has never been built, `rebuild` acts exactly as
 Removes the specified version of PostgreSQL unless it is the currently-active
 version. Use the `clear` command to clear the active version before removing it.
 
-``` sh
+```
 $ pgenv remove 10.3
 PostgreSQL 10.3 removed
 ```
@@ -441,7 +441,7 @@ one. It is also possible to indicate a major version to narrow the scope of the
 special keywords. As an example:
 
 ``` sh
-$ pgenv remove latest 10
+pgenv remove latest 10
 ```
     
 will remove the most recent PostgreSQL version of the 10 series installed.    
@@ -451,7 +451,7 @@ will remove the most recent PostgreSQL version of the 10 series installed.
 Starts the currently active version of PostgreSQL if it's not already running.
 Initializes the data directory if none exists.
 
-``` sh
+``` 
 $ pgenv start
 PostgreSQL started
 ```
@@ -465,7 +465,7 @@ directory, nor the log file.
 
 Stops the currently active version of PostgreSQL.
 
-``` sh
+``` 
 $ pgenv stop
 PostgreSQL 10.5 stopped
 ```
@@ -479,7 +479,7 @@ It is possible to specify flags to pass to `pg_ctl(1)` when performing the
 Restarts the currently active version of PostgreSQL, or starts it if it's not
 already running.
 
-``` sh
+``` 
 $ pgenv restart
 PostgreSQL 10.1 restarted
 Logging to pgsql/data/server.log
@@ -495,7 +495,7 @@ Shows all the versions of PostgreSQL available to download and build. Handy to
 help you finding a version to pass to the `build` command. Note that the
 `available` command produces copious output.
 
-``` sh
+``` 
 $ pgenv available
 
             Available PostgreSQL Versions
@@ -539,7 +539,7 @@ version may be passed to the `build` command.
 To limit the list to versions for specific major releases, pass them to
 `available`. For example, to list only the `9.6` and `10` available versions:
 
-``` sh 
+```  
 $ pgenv available 10 9.6
             Available PostgreSQL Versions
 ========================================================
@@ -565,7 +565,7 @@ the command was not found.
 Outputs a brief usage statement and summary of available commands, like the
 following:
 
-``` sh 
+``` 
 $ pgenv help
 Usage: pgenv <command> [<args>]
 
@@ -635,14 +635,14 @@ program will work against the currently active version of PostgreSQL.
 
 In order to start with a default configuration, use the `write` subcommand:
 
-``` sh 
+``` 
 $ pgenv config write default
 pgenv configuration file ~/.pgenv/.pgenv.default.conf written
 ```
 
 A subsequent `show` displays the defaults:
 
-``` sh
+``` 
 $ pgenv config show default
 # Default configuration
 # pgenv configuration for PostgreSQL
@@ -690,7 +690,7 @@ After a configuration file has been created by `init`, the `write` or `edit`
 commands must be used against it, that means an existing configuration file
 cannot be `init`ed more than once.
 
-``` sh
+``` 
 $ pgenv config write 10.5
 pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
 ```
@@ -702,16 +702,15 @@ been created.
 
 Use the `edit` subcommand to edit a configuration file in your favorite editor:
 
-```
-$ pgenv config edit 10.5
-# $EDITOR is fired up 
+``` sh 
+pgenv config edit 10.5
 ```
 
 The `edit` command will start your favorite editor, that is whatever it is set
 within the `EDITOR` variable. If such variable is not set you will be warned.
 Use the `delete` subcommand to delete a configuration:
 
-``` sh
+``` 
 $ pgenv config delete 10.5
 Configuration file ~/.pgenv/.pgenv.10.5.conf (and backup) deleted
 ```
@@ -722,7 +721,7 @@ file, since it can be shared among different PostgreSQL versions.
 However, if it is explicitly specified `default` as the version to delete
 (i.e., `config delete default`), the default configuration file will be deleted.
       
-``` sh 
+``` 
 $ pgenv config delete
 Cannot delete default configuration while version configurations exist
 To remove it anyway, delete ~/.pgenv/.pgenv.default.conf.
@@ -735,8 +734,8 @@ Please note that since commit [5839e721] the file name of the default
 configuration file has changed. In the case you want to convert your default
 configuration file, please issue a rename like the following
 
-``` sh
-$ cp .pgenv.conf .pgenv.default.conf
+``` sh 
+cp .pgenv.conf .pgenv.default.conf
 ```
 
 ### pgenv log
@@ -746,7 +745,7 @@ don't have to worry about the exact log location. The log is dumped using the
 `tail` command, and every option passed to the command line is passed thru
 `tail`. As an example:
 
-``` sh 
+``` 
 $ pgenv log     
 Dumping the content of /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 
@@ -765,12 +764,12 @@ LOG:  database system is ready to accept connections
 The above is equivalent to manually executing
 
 ``` sh
-$ tail ~/git/misc/PostgreSQL/pgenv/pgsql/data/server.log
+tail ~/git/misc/PostgreSQL/pgenv/pgsql/data/server.log
 ```
 
 It is possible to pass arguments to `tail` as command line flags:
 
-``` sh
+``` 
 $ pgenv log -n 2
 Dumping the content of /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 
@@ -781,13 +780,13 @@ LOG:  database system is ready to accept connections
 which results in executing
 
 ``` sh
-$ tail -n 2 /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
+tail -n 2 /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 ```
 
 and of course, you can inspect the log of live system continuously:
 
 ``` sh
-$ pgenv log -f
+pgenv log -f
 ```    
 
 # Bug Reporting

--- a/README.md
+++ b/README.md
@@ -609,12 +609,12 @@ appropriate values, or falls back on its own defaults.
 The `config` command accepts the following subcommands:
 
 
-- `show` prints the current or specified version configuration
-- `init` produces a configuration file from scratch, with default settings
-- `write` store the specified version configuration
-- `edit` opens the current or specified version configuration file in your favourite text editor 
-        (Using `$EDITOR`, e.g: `export EDITOR=/usr/bin/emacs`)
-- `delete` removes the specified configuration
+-    `show` prints the current or specified version configuration
+-    `init` produces a configuration file from scratch, with default settings
+-    `write` store the specified version configuration
+-    `edit` opens the current or specified version configuration file in your favourite text editor 
+           (Using `$EDITOR`, e.g: `export EDITOR=/usr/bin/emacs`)
+-    `delete` removes the specified configuration
  
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a

--- a/README.md
+++ b/README.md
@@ -720,24 +720,19 @@ The `delete` subcommand will not attempt to delete the default configuration
 file, since it can be shared among different PostgreSQL versions.
 However, if it is explicitly specified `default` as the version to delete
 (i.e., `config delete default`), the default configuration file will be deleted.
-
-         
-
+      
 ```
 pgenv config delete
 Cannot delete default configuration while version configurations exist
 To remove it anyway, delete ~/.pgenv/.pgenv.default.conf.
 ```
-
 The `delete` subcommand deletes both the configuration file and its backup copy.
 The `pgenv remove` command also deletes any configuration for the removed
 version.
 
-
 Please note that since commit [5839e721] the file name of the default
 configuration file has changed. In the case you want to convert your default
 configuration file, please issue a rename like the following
-
 
 ``` sh
 cp .pgenv.conf .pgenv.default.conf

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installation
 1.  Check out pgenv into `~/.pgenv`.
 
     ``` sh
-    git clone https://github.com/theory/pgenv.git ~/.pgenv
+    $ git clone https://github.com/theory/pgenv.git ~/.pgenv
     ```
 
 2.  Add `~/.pgenv/bin` and `~/.pgenv/pgsql/bin` to your `$PATH` for access to
@@ -60,7 +60,7 @@ Installation
     PostgreSQL:
    
     ``` sh
-    echo 'export PATH="$HOME/.pgenv/bin:$HOME/.pgenv/pgsql/bin:$PATH"' >> ~/.bash_profile
+    $ echo 'export PATH="$HOME/.pgenv/bin:$HOME/.pgenv/pgsql/bin:$PATH"' >> ~/.bash_profile
     ```
 
     **Ubuntu note**: Modify your `~/.profile` instead of `~/.bash_profile`.
@@ -71,13 +71,13 @@ Installation
     can now begin using pgenv.
 
     ``` sh
-    exec $SHELL -l
+    $ exec $SHELL -l
     ```
 
 4.  Build a version of PostgreSQL:
 
     ``` sh
-    pgenv build 10.4
+    $ pgenv build 10.4
     ```
 
 ### Configuration
@@ -138,8 +138,8 @@ The above configuration variables can be set in the configuration file or on the
 fly, for instance:
 
 ``` sh
-export PGENV_SCRIPT_POSTSTART=/usr/local/bin/load_data.sh
-pgenv start 12.0
+$ export PGENV_SCRIPT_POSTSTART=/usr/local/bin/load_data.sh
+$ pgenv start 12.0
 ```
 
 It is worth noting that the start, restart and post script are not shared
@@ -185,9 +185,9 @@ Some commands require you to specify the PostgreSQL version to act on.
 You can specify the version the command applies to by either entering the
 PostgreSQL version number or by specifying any of the special keywords:
 
-- `current` or `version` to indicate the currently selected PostgreSQL version;
-- `earliest` to indicate the oldest installed version (excluding beta versions);
-- `newest` to indicate the newest installed version (excluding beta versions).
+-    `current` or `version` to indicate the currently selected PostgreSQL version;
+-    `earliest` to indicate the oldest installed version (excluding beta versions);
+-    `newest` to indicate the newest installed version (excluding beta versions).
 
 It is important to note that `earliest` and `latest` have nothing to do with the
 time you installed PostgreSQL by means of `pgenv`: they refer only to PostgreSQL
@@ -214,8 +214,8 @@ stopped before switching. If the specified version is already in use, the `use`
 command won't stop it, but will initialize its data directory and starts it if
 it's not already running.
 
-```
-pgenv use 10.4
+``` sh
+$ pgenv use 10.4
 waiting for server to shut down.... done
 server stopped
 waiting for server to start.... done
@@ -229,7 +229,7 @@ one. It is also possible to indicate a major version to narrow the scope of the
 special keywords. As an example:
 
 ``` sh
-pgenv use latest 10
+$ pgenv use latest 10
 ```
 
 will select the most recent PostgreSQL version of the 10 series installed.    
@@ -241,8 +241,8 @@ the currently active version (if any). The first column reports versions
 available for use by `pgenv` and the second lists the subdirectory of
 `$PGENV_ROOT` in which the each version is installed:
 
-```
-pgenv versions
+``` sh
+$ pgenv versions
       10.4      pgsql-10.4
       11beta3   pgsql-11beta3
       9.5.13    pgsql-9.5.13
@@ -257,15 +257,15 @@ Each version is installed in a `pgsql-` subdirectory of `$PGENV_ROOT`.
 
 Displays the currently active PostgreSQL version.
 
-```
-pgenv current
+``` sh
+$ pgenv current
 10.4
 ```
 
 Please note that `version` is a command synonym for version:
 
-```
-pgenv version
+``` sh
+$ pgenv version
 10.4
 ```
 
@@ -274,8 +274,8 @@ pgenv version
 Clears the currently active version of PostgreSQL. If the current version is
 running, `clear` will stop it before clearing it.
 
-```
-pgenv clear
+``` sh
+$ pgenv clear
 waiting for server to shut down.... done
 server stopped
 PostgreSQL stopped
@@ -290,8 +290,8 @@ process to patch the source tree, see the section on patching later on. If the
 version is already built, it will not be rebuilt; use `clear` to remove an
 existing version before building it again.
 
-```
-pgenv build 10.3
+``` sh
+$ pgenv build 10.3
 # [Curl, configure, and make output elided]
 PostgreSQL 10.3 built
 ```
@@ -302,7 +302,7 @@ warning is shown to the user to remind she can edit a configuration file and
 start over the build process:
 
 ```sh
-pgenv build 10.3
+$ pgenv build 10.3
   ...
 WARNING: no configuration file found for version 10.3
 HINT: if you wish to customize the build process please
@@ -318,7 +318,7 @@ PL/Perl, it is possible to configure the variable `PGENV_CONFIGURE_OPTIONS`
 adding `--with-perl`. Or say you need SSL support and to tell teh compiler to
 use Homebrew-installed OpenSSL. Edit it something like:
 
-``` sh
+``` 
 PGENV_CONFIGURE_OPTIONS=(
     --with-perl
     --with-openssl
@@ -331,18 +331,19 @@ Please note that it is possible to pass argument variables within the command
 line to instrument the build phase. As an example, the following is a possible
 workflow to configure and build a customized 10.5 instance:
 
-``` sh
-pgenv config write 10.5
+``` 
+$ pgenv config write 10.5
 pgenv config edit 10.5
 # adjust PGENV_CONFIGURE_OPTIONS
-pgenv build 10.5
+
+$ pgenv build 10.5
 ```
 
 In the case you need to specify a particular variable, such as the Perl
 interpreter, pass it on the command line at the time of build:
 
 ``` sh
-PERL=/usr/local/my-fancy-perl pgenv build 10.5
+$ PERL=/usr/local/my-fancy-perl pgenv build 10.5
 ```
 
 #### Patching
@@ -362,7 +363,7 @@ version and Operating System or a mix of possible combinations of those. As an
 example, in the case of the PostgreSQL version 8.1.4 the index files is searched
 among one of the following:
 
-``` sh
+``` 
 $PGENV_ROOT/patch/index/patch.8.1.4.Linux
 $PGENV_ROOT/patch/index/patch.8.1.4
 $PGENV_ROOT/patch/index/patch.8.1.Linux
@@ -384,8 +385,8 @@ It is possible to specify a particular index file, that means avoid the
 automatic index selection, by either setting the `PGENV_PATCH_INDEX` variable on
 the command line or in the configuration file. As an example
 
-``` sh
-PGENV_PATCH_INDEX=/src/my-patch-list.txt pgenv build 10.5
+``` 
+$ PGENV_PATCH_INDEX=/src/my-patch-list.txt pgenv build 10.5
 ```
 
 #### Build special keywords
@@ -427,8 +428,8 @@ In the case a specific version has never been built, `rebuild` acts exactly as
 Removes the specified version of PostgreSQL unless it is the currently-active
 version. Use the `clear` command to clear the active version before removing it.
 
-```
-pgenv remove 10.3
+``` sh
+$ pgenv remove 10.3
 PostgreSQL 10.3 removed
 ```
 
@@ -439,8 +440,8 @@ respectively indicate the oldest PostgreSQL version installed and the newest
 one. It is also possible to indicate a major version to narrow the scope of the
 special keywords. As an example:
 
-```
-pgenv remove latest 10
+``` sh
+$ pgenv remove latest 10
 ```
     
 will remove the most recent PostgreSQL version of the 10 series installed.    
@@ -450,8 +451,8 @@ will remove the most recent PostgreSQL version of the 10 series installed.
 Starts the currently active version of PostgreSQL if it's not already running.
 Initializes the data directory if none exists.
 
-```
-pgenv start
+``` sh
+$ pgenv start
 PostgreSQL started
 ```
     
@@ -464,8 +465,8 @@ directory, nor the log file.
 
 Stops the currently active version of PostgreSQL.
 
-```
-pgenv stop
+``` sh
+$ pgenv stop
 PostgreSQL 10.5 stopped
 ```
 
@@ -478,8 +479,8 @@ It is possible to specify flags to pass to `pg_ctl(1)` when performing the
 Restarts the currently active version of PostgreSQL, or starts it if it's not
 already running.
 
-```
-pgenv restart
+``` sh
+$ pgenv restart
 PostgreSQL 10.1 restarted
 Logging to pgsql/data/server.log
 ```
@@ -495,7 +496,7 @@ help you finding a version to pass to the `build` command. Note that the
 `available` command produces copious output.
 
 ``` sh
-pgenv available
+$ pgenv available
 
             Available PostgreSQL Versions
 ========================================================
@@ -538,8 +539,8 @@ version may be passed to the `build` command.
 To limit the list to versions for specific major releases, pass them to
 `available`. For example, to list only the `9.6` and `10` available versions:
 
-```
-pgenv available 10 9.6
+``` sh 
+$ pgenv available 10 9.6
             Available PostgreSQL Versions
 ========================================================
 
@@ -564,8 +565,8 @@ the command was not found.
 Outputs a brief usage statement and summary of available commands, like the
 following:
 
-```
-pgenv help
+``` sh 
+$ pgenv help
 Usage: pgenv <command> [<args>]
 
 The pgenv commands are:
@@ -634,15 +635,15 @@ program will work against the currently active version of PostgreSQL.
 
 In order to start with a default configuration, use the `write` subcommand:
 
-```
-pgenv config write default
+``` sh 
+$ pgenv config write default
 pgenv configuration file ~/.pgenv/.pgenv.default.conf written
 ```
 
 A subsequent `show` displays the defaults:
 
 ``` sh
-pgenv config show default
+$ pgenv config show default
 # Default configuration
 # pgenv configuration for PostgreSQL
 # File: /home/luca/git/misc/PostgreSQL/pgenv/.pgenv.default.conf
@@ -690,7 +691,7 @@ commands must be used against it, that means an existing configuration file
 cannot be `init`ed more than once.
 
 ``` sh
-pgenv config write 10.5
+$ pgenv config write 10.5
 pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
 ```
 
@@ -702,8 +703,8 @@ been created.
 Use the `edit` subcommand to edit a configuration file in your favorite editor:
 
 ```
-pgenv config edit 10.5
-<output omitted>
+$ pgenv config edit 10.5
+# $EDITOR is fired up 
 ```
 
 The `edit` command will start your favorite editor, that is whatever it is set
@@ -711,7 +712,7 @@ within the `EDITOR` variable. If such variable is not set you will be warned.
 Use the `delete` subcommand to delete a configuration:
 
 ``` sh
-pgenv config delete 10.5
+$ pgenv config delete 10.5
 Configuration file ~/.pgenv/.pgenv.10.5.conf (and backup) deleted
 ```
    
@@ -721,8 +722,8 @@ file, since it can be shared among different PostgreSQL versions.
 However, if it is explicitly specified `default` as the version to delete
 (i.e., `config delete default`), the default configuration file will be deleted.
       
-```
-pgenv config delete
+``` sh 
+$ pgenv config delete
 Cannot delete default configuration while version configurations exist
 To remove it anyway, delete ~/.pgenv/.pgenv.default.conf.
 ```
@@ -735,7 +736,7 @@ configuration file has changed. In the case you want to convert your default
 configuration file, please issue a rename like the following
 
 ``` sh
-cp .pgenv.conf .pgenv.default.conf
+$ cp .pgenv.conf .pgenv.default.conf
 ```
 
 ### pgenv log
@@ -745,48 +746,48 @@ don't have to worry about the exact log location. The log is dumped using the
 `tail` command, and every option passed to the command line is passed thru
 `tail`. As an example:
 
-```
-pgenv log     
+``` sh 
+$ pgenv log     
 Dumping the content of /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 
-2020-08-28 19:04:44.199 CEST [10702] LOG:  could not bind IPv4 address "127.0.0.1": Address already in use
-2020-08-28 19:04:44.199 CEST [10702] HINT:  Is another postmaster already running on port 5432? If not, wait a few seconds and retry.
-2020-08-28 19:04:44.199 CEST [10702] WARNING:  could not create listen socket for "localhost"
-2020-08-28 19:04:44.199 CEST [10702] FATAL:  could not create any TCP/IP sockets
-2020-08-28 19:04:44.199 CEST [10702] LOG:  database system is shut down
-2020-08-28 19:09:09.024 CEST [11867] LOG:  starting PostgreSQL 12.1 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0, 64-bit
-2020-08-28 19:09:09.024 CEST [11867] LOG:  listening on IPv4 address "127.0.0.1", port 5432
-2020-08-28 19:09:09.028 CEST [11867] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
-2020-08-28 19:09:09.045 CEST [11868] LOG:  database system was shut down at 2020-08-28 12:57:33 CEST
-2020-08-28 19:09:09.048 CEST [11867] LOG:  database system is ready to accept connections
+LOG:  could not bind IPv4 address "127.0.0.1": Address already in use
+HINT:  Is another postmaster already running on port 5432? If not, wait a few seconds and retry.
+WARNING:  could not create listen socket for "localhost"
+FATAL:  could not create any TCP/IP sockets
+LOG:  database system is shut down
+LOG:  starting PostgreSQL 12.1 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0, 64-bit
+LOG:  listening on IPv4 address "127.0.0.1", port 5432
+LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
+LOG:  database system was shut down at 2020-08-28 12:57:33 CEST
+LOG:  database system is ready to accept connections
  ```
 
 The above is equivalent to manually executing
 
 ``` sh
-tail /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log
+$ tail ~/git/misc/PostgreSQL/pgenv/pgsql/data/server.log
 ```
 
 It is possible to pass arguments to `tail` as command line flags:
 
-```
-pgenv log -n 2
+``` sh
+$ pgenv log -n 2
 Dumping the content of /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 
-2020-08-28 19:09:09.045 CEST [11868] LOG:  database system was shut down at 2020-08-28 12:57:33 CEST
-2020-08-28 19:09:09.048 CEST [11867] LOG:  database system is ready to accept connections
+LOG:  database system was shut down at 2020-08-28 12:57:33 CEST
+LOG:  database system is ready to accept connections
 ```
 
 which results in executing
 
 ``` sh
-tail -n 2 /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
+$ tail -n 2 /home/luca/git/misc/PostgreSQL/pgenv/pgsql/data/server.log 
 ```
 
 and of course, you can inspect the log of live system continuously:
 
 ``` sh
-pgenv log -f
+$ pgenv log -f
 ```    
 
 # Bug Reporting

--- a/README.md
+++ b/README.md
@@ -554,9 +554,11 @@ the appropriate values, or falls back on its own defaults.
 The `config` command accepts the following subcommands:
 
 - `show` prints the current or specified version configuration
-- `write` store the current or specified version configuration
+- `init` produces a blank configuration file, with standard settings
+- `write` store the specified version configuration
 - `edit` opens the current or specified version configuration in an editor (Using $EDITOR, e.g: export EDITOR=/usr/bin/vim)
 - `delete` removes the specified configuration
+- `nuke` similar to `delete`, that removes also the default configuration if none is specified
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a
 special keyword:
@@ -568,6 +570,7 @@ special keyword:
 version of PostgreSQL installed. As in other commands, these two keywords
 can be combined with a PostgreSQL major version number to point to the
 configuration of the earliest/latest version within that major number.
+
 
 
 
@@ -620,14 +623,19 @@ PGENV_INITDB_OPTS='-U postgres --locale en_US.UTF-8 --encoding UNICODE'
 
 You can edit the file and adjust parameters to your needs.
 
-In order to create a configuration file for a specific version, pass the
-version to the `write` subcommand:
+In order to create a configuration file for a specific version, it is possible
+to use the `init` or `write` commands. If no prior default configuration exists,
+the commands do the same, that is they create a from-scratch configuration file.
+If a default configuration exists, the `write` command will "clone" such configuration
+in a PostgreSQL version specific configuration file, while `init` will 
+create a blank configuration file.
 
    $ pgenv config write 10.5
    pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
 
 Each time pgenv writes a configuration file, it first creates a backup with
-the suffix `.backup`.
+the suffix `.backup` and a timestamp string related to when the backup file has
+been created.
 
 Use the `edit` subcommand to edit a configuration file in your favourite
 editor:
@@ -643,18 +651,25 @@ Use the `delete` subcommand to delete a configuration:
    $ pgenv config delete 10.5
    Configuration file ~/.pgenv/.pgenv.10.5.conf (and backup) deleted
 
-Note that you cannot delete the default configuration unless all other
-versions have been removed (e.g., by `pgenv remove`). This prevents accidental
-loss of configuration:
+The `delete` subcommand will not attempt to delete the default configuration
+file, since it can be shared among different PostgreSQL versions.
+However, if it is explicitly specified `default` as the version to delete
+(i.e., `config delete default`) or the `config nuke` command is run, the
+default configuration file will be deleted.
 
-   $ pgenv config delete
-   Cannot delete default configuration while version configurations exist
-   To remove it anyway, delete ~/.pgenv/.pgenv.default.conf.
+         
 
 The `delete` subcommand deletes both the configuration file and its backup
 copy. The `pgenv remove` command also deletes any configuration for the
 removed version.
 
+
+The `nuke` subcommand behaves as `delete`, but allows for deletion of the default
+configuration file even if it is not explicitly specified as argument. In other
+words, the two following commands are the same
+
+    $ pgenv config delete default
+    $ pgenv config nuke
 
 Please note that since commit [5839e721](https://github.com/theory/pgenv/commit/5839e721d43c9eae8b4a0d61ba78996c220a4da0) 
 the file name of the default configuration file has changed. In the case you want to convert your 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -547,8 +547,12 @@ pgenv_configuration_delete(){
     # no installed instances
     if [ "$PGENV_CONFIG_FILE" = "$PGENV_DEFAULT_CONFIG_FILE" ]; then
         if [ -z "$nuke" ]; then
-            echo "To delete the default configuration file [$PGENV_DEFAULT_CONFIG_FILE] you need to run"
-            echo "the \`config nuke\` command"
+            cat <<EOF >&2
+No specific version specified, automatically selected the "default" one.
+To delete the default configuration file in
+   $PGENV_DEFAULT_CONFIG_FILE
+you need to run the \`config delete default\` command explicitly.
+EOF
             exit 1
         fi
         local installed_versions=0

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -548,8 +548,8 @@ pgenv_configuration_delete(){
 
     # remove the file
     pgenv_debug "Deleting configuration file [$PGENV_CONFIG_FILE]"
-    rm -f "$PGENV_CONFIG_FILE"           # remove config file
-    rm -f "${PGENV_CONFIG_FILE}.backup"  # remove also backup file
+    rm -f "$PGENV_CONFIG_FILE"            # remove config file
+    rm -f ${PGENV_CONFIG_FILE}*.backup    # remove also backup file
     echo "Configuration file $PGENV_CONFIG_FILE (and backup) deleted"
 }
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1468,8 +1468,6 @@ EOF
                 ;;
             delete)
                 pgenv_configuration_delete "$v" "$nuke";;
-            nuke)
-                pgenv_configuration_delete "$v" "default";;
             *)
                 if [ -z "$action" ]; then
                     cat <<EOF >&2
@@ -1480,7 +1478,6 @@ You need to specify one of the following \`config\` actions to perform:
     write
     edit
     delete
-    nuke
 
 
 For instance:

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -619,8 +619,8 @@ pgenv_configuration_write() {
     # ok, write the configuration
     echo "# pgenv configuration created on $(date)" > "$CONF"
     echo "" >> "$CONF"
-    pgenv_configuration_write_variable "$CONF" "PGENV_DEBUG" "" 'Enables debug output'
-    pgenv_configuration_write_variable "$CONF" "PGENV_WARNINGS" "true" 'Enables warning messages'
+    pgenv_configuration_write_variable "$CONF" "PGENV_DEBUG" "$PGENV_DEBUG" 'Enables debug output'
+    pgenv_configuration_write_variable "$CONF" "PGENV_WARNINGS" "$PGENV_WARNINGS" 'Enables warning messages'
 
     echo "###### Build settings #####" >> "$CONF"
     pgenv_configuration_write_variable "$CONF" "PGENV_MAKE" "$PGENV_MAKE" 'Make command to use for build'
@@ -1435,6 +1435,10 @@ EOF
                 # in an explicit write load first the variables from the runtime
                 # environment, so PL/Perl, make, and stuff can be already set
                 pgenv_check_dependencies
+                pgenv_configuration_write "$v" ;;
+            write)
+                # load default configuration if exists
+                pgenv_configuration_load
                 pgenv_configuration_write "$v" ;;
             edit)
                 configuration_file=$( pgenv_configuration_file_name $v )

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -605,7 +605,7 @@ pgenv_configuration_write() {
 
     # make a backup copy
     if [ -f "$CONF" ]; then
-        CONF_BACKUP="${CONF}.backup"
+        CONF_BACKUP="${CONF}.$(date +'%Y-%m-%dT%H-%M').backup"
         pgenv_debug "Making backup copy of [$CONF] into [$CONF_BACKUP]"
         mv "$CONF" "$CONF_BACKUP"
     fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -542,7 +542,7 @@ pgenv_configuration_delete(){
     local PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
     local PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
 
-    pgenv_debug "\`config delete` for version [$v] (nuke [$nuke])"
+    pgenv_debug "\`config delete\` for version [$v] (nuke [$nuke])"
 
     # if the file is the default one, delete only if there are
     # no installed instances and the version has been explicitly

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -522,13 +522,19 @@ pgenv_configuration_load(){
 # on this system.
 pgenv_configuration_delete(){
     local v=$1
+    local nuke=$2
     local PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
     local PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
 
 
-    # if the file is the default one, delete only if there are
-    # no installed instances
+    # if the file is the default one, delete only if the user
+    # is really sure, without any regard about the installed versions
     if [ "$PGENV_CONFIG_FILE" = "$PGENV_DEFAULT_CONFIG_FILE" ]; then
+        if [ -z "$nuke" ]; then
+            echo "To delete the default configuration file [$PGENV_DEFAULT_CONFIG_FILE] you need to run"
+            echo "the \`config nuke\` command"
+            exit 1
+        fi
         local installed_versions=0
         for installed in $( ls -d pgsql-* 2>/dev/null )
         do
@@ -1405,9 +1411,13 @@ EOF
 
         if [ -z "$3" ]; then
             v="default"
+            nuke=""
         else
             # understand the version the user wants to configure
             v=$( pgenv_guess_postgresql_version $3 $4 )
+            if [ "$3" = "default" ]; then
+                nuke="default"
+            fi
         fi
 
         # get the currently in use if none specified
@@ -1445,16 +1455,21 @@ EOF
                 fi
                 ;;
             delete)
-                pgenv_configuration_delete "$v" ;;
+                pgenv_configuration_delete "$v" "$nuke";;
+            nuke)
+                pgenv_configuration_delete "$v" "default";;
             *)
                 if [ -z "$action" ]; then
                     cat <<EOF >&2
 You need to specify one of the following \`config\` actions to perform:
 
     show
+    init
     write
     edit
     delete
+    nuke
+
 
 For instance:
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -2,7 +2,7 @@
 #
 # VERSION
 #
-PGENV_VERSION="1.1.0"
+PGENV_VERSION="1.2.0"
 
 # https://stackoverflow.com/a/19622569/79202
 trap 'exit' ERR

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1427,11 +1427,20 @@ EOF
         fi
 
         title="PostgreSQL version $v"
+        configuration_file=$( pgenv_configuration_file_name $v )
 
         case $action in
             show)
                 pgenv_configuration_dump_or_exit "$v" "$title" ;;
             init)
+                # check that the file does not exist, so
+                # that the program does not re-initialize it
+                if [ -f "$configuration_file" ]; then
+                    echo "Configuration file [$configuration_file] for version [$v] already exists"
+                    echo "Cannot re-init it!"
+                    exit 1
+                fi
+
                 # in an explicit write load first the variables from the runtime
                 # environment, so PL/Perl, make, and stuff can be already set
                 pgenv_check_dependencies
@@ -1441,7 +1450,6 @@ EOF
                 pgenv_configuration_load
                 pgenv_configuration_write "$v" ;;
             edit)
-                configuration_file=$( pgenv_configuration_file_name $v )
                 if [ ! -z "$EDITOR" ] && [ $(command -v $EDITOR ) ]; then
                     pgenv_debug "Launching editor $EDITOR"
                     $EDITOR $configuration_file

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -575,7 +575,7 @@ EOF
         fi
         # if the file is not here, nothing to do!
       elif [ ! -f "$PGENV_CONFIG_FILE" ]; then
-            echo "No configuration file bound to version $v to delete"
+            echo "No configuration file to delete fo version $v"
             exit 1
     fi
 
@@ -1447,7 +1447,7 @@ EOF
                 # check that the file does not exist, so
                 # that the program does not re-initialize it
                 if [ -f "$configuration_file" ]; then
-                    pgenv_debug "Cannot init [$configuration_file] for version [$v]: file already existing"
+                    pgenv_debug "Cannot init [$configuration_file] for version [$v]: file already exists"
                     echo "Configuration file [$configuration_file] already exists, cannot re-init it!"
                     exit 1
                 fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1447,7 +1447,7 @@ EOF
                 # check that the file does not exist, so
                 # that the program does not re-initialize it
                 if [ -f "$configuration_file" ]; then
-                    pgenv_debug "Cannot init [$configuration_file] for version [$v]: file already exists"
+                    pgenv_debug "init $v -> [$configuration_file]"
                     echo "Configuration file [$configuration_file] already exists, cannot re-init it!"
                     exit 1
                 fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -542,6 +542,7 @@ pgenv_configuration_delete(){
     local PGENV_DEFAULT_CONFIG_FILE=$( pgenv_configuration_file_name )
     local PGENV_CONFIG_FILE=$( pgenv_configuration_file_name $v )
 
+    pgenv_debug "\`config delete` for version [$v] (nuke [$nuke])"
 
     # if the file is the default one, delete only if there are
     # no installed instances and the version has been explicitly

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -544,7 +544,8 @@ pgenv_configuration_delete(){
 
 
     # if the file is the default one, delete only if there are
-    # no installed instances
+    # no installed instances and the version has been explicitly
+    # indicated by the user
     if [ "$PGENV_CONFIG_FILE" = "$PGENV_DEFAULT_CONFIG_FILE" ]; then
         if [ -z "$nuke" ]; then
             cat <<EOF >&2
@@ -562,13 +563,18 @@ EOF
         done
 
         if [ $installed_versions -gt 0 ]; then
-            echo "Cannot delete default configuration while version configurations exist"
-            echo "To remove it anyway, delete $PGENV_CONFIG_FILE"
+            cat <<EOF >&2
+Cannot delete default configuration file while PostgreSQL versions exists:
+the file could be shared among such installations.
+If you really want to delete the default configuration file
+execute a command like
+   rm $PGENV_CONFIG_FILE
+EOF
             exit 1
         fi
         # if the file is not here, nothing to do!
       elif [ ! -f "$PGENV_CONFIG_FILE" ]; then
-            echo "No configuration to delete"
+            echo "No configuration file bound to version $v to delete"
             exit 1
     fi
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1421,7 +1421,7 @@ EOF
         case $action in
             show)
                 pgenv_configuration_dump_or_exit "$v" "$title" ;;
-            write)
+            init)
                 # in an explicit write load first the variables from the runtime
                 # environment, so PL/Perl, make, and stuff can be already set
                 pgenv_check_dependencies

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1436,8 +1436,8 @@ EOF
                 # check that the file does not exist, so
                 # that the program does not re-initialize it
                 if [ -f "$configuration_file" ]; then
-                    echo "Configuration file [$configuration_file] for version [$v] already exists"
-                    echo "Cannot re-init it!"
+                    pgenv_debug "Cannot init [$configuration_file] for version [$v]: file already existing"
+                    echo "Configuration file [$configuration_file] already exists, cannot re-init it!"
                     exit 1
                 fi
 


### PR DESCRIPTION
See #47.

Now there are different `config` subcommands:
- `config init` creates always a blank configuration file
- - `config write` creates a configuration file with the default configuration if exists, or a blank file otherwise
- - `config delete` does not delete the default configuration file unless explicitly indicated as `config delete default`
- - `config nuke` deletes every configuration specified, even the default if not passed as argument.