### PR TITLE
Configuration files directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /pgsql*
 /src/
 /.pgenv.*
+/config/

--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ The `config` command accepts the following subcommands:
 -    `edit` opens the current or specified version configuration file in your favourite text editor 
            (Using `$EDITOR`, e.g: `export EDITOR=/usr/bin/emacs`)
 -    `delete` removes the specified configuration
+-    `migrate` is a command used to change the configuration format between versions of `pgenv`
  
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a
@@ -738,23 +739,20 @@ configuration file, please issue a rename like the following
 cp .pgenv.conf .pgenv.default.conf
 ```
 
-Please note also that, since version `1.2.1` [811ba05], all the configuration files
-have been moved into the `config` subdirectory, so to keep them in a single place.
-In order to "migrate" your existing configuration, you have to manually
-copy all the `.pgenv.*.conf` files into the `config` subdirectory.
-The best way to quickly migrate your configuration files to the new
-naming scheme, is running a small shell loop as the following one:
+
+The `migrate` command allows `pgenv` to change the configuration format of
+the files between different releases. For example, it must be run if
+you are upgrading `pgenv` from a version before `1.2.1` [811ba05], that changed the
+location of configuration files into the `config` subdirectory.
 
 
 ```
-for f in .pgenv.*.conf; do
-  F=$( echo $f | sed 's/\.pgenv\.//' ); mv $f config/$F;
-done
+pgenv config migrate
+Migrated 3 configuration files from previous versions (0 missing)
+Your configuration files are now into [~/git/misc/PostgreSQL/pgenv/config]
 ```
 
-that has to be run from your `$PGENV_ROOT`, that is from the directory that
-contains the `.pgenv.*.conf` files.
-
+ 
 ### pgenv log
 
 The `log` command provides a dump of the cluster log, if it exists, so that you

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ In order to start with a default configuration, use the `write` subcommand:
 
 ``` 
 $ pgenv config write default
-pgenv configuration file ~/.pgenv/config/.pgenv.default.conf written
+pgenv configuration file ~/.pgenv/config/default.conf written
 ```
 
 A subsequent `show` displays the defaults:
@@ -646,7 +646,7 @@ A subsequent `show` displays the defaults:
 $ pgenv config show default
 # Default configuration
 # pgenv configuration for PostgreSQL
-# File: /home/luca/git/misc/PostgreSQL/pgenv/config/.pgenv.default.conf
+# File: /home/luca/git/misc/PostgreSQL/pgenv/config/default.conf
 # ---------------------------------------------------
 # pgenv configuration created on mer 12 set 2018, 08.35.52, CEST
 
@@ -692,7 +692,7 @@ cannot be `init`ed more than once.
 
 ``` 
 $ pgenv config write 10.5
-pgenv configuration file [~/.pgenv/config/.pgenv.10.5.conf] written
+pgenv configuration file [~/.pgenv/config/10.5.conf] written
 ```
 
 
@@ -712,7 +712,7 @@ Use the `delete` subcommand to delete a configuration:
 
 ``` 
 $ pgenv config delete 10.5
-Configuration file ~/.pgenv/config/.pgenv.10.5.conf (and backup) deleted
+Configuration file ~/.pgenv/config/10.5.conf (and backup) deleted
 ```
    
 
@@ -724,7 +724,7 @@ However, if it is explicitly specified `default` as the version to delete
 ``` 
 $ pgenv config delete
 Cannot delete default configuration while version configurations exist
-To remove it anyway, delete ~/.pgenv/config/.pgenv.default.conf.
+To remove it anyway, delete ~/.pgenv/config/default.conf.
 ```
 The `delete` subcommand deletes both the configuration file and its backup copy.
 The `pgenv remove` command also deletes any configuration for the removed
@@ -742,6 +742,18 @@ Please note also that, since version `1.2.1` [811ba05], all the configuration fi
 have been moved into the `config` subdirectory, so to keep them in a single place.
 In order to "migrate" your existing configuration, you have to manually
 copy all the `.pgenv.*.conf` files into the `config` subdirectory.
+The best way to quickly migrate your configuration files to the new
+naming scheme, is running a small shell loop as the following one:
+
+
+```
+for f in .pgenv.*.conf; do
+  F=$( echo $f | sed 's/\.pgenv\.//' ); mv $f config/$F;
+done
+```
+
+that has to be run from your `$PGENV_ROOT`, that is from the directory that
+contains the `.pgenv.*.conf` files.
 
 ### pgenv log
 

--- a/README.md
+++ b/README.md
@@ -748,8 +748,8 @@ location of configuration files into the `config` subdirectory.
 
 ```
 pgenv config migrate
-Migrated 3 configuration files from previous versions (0 missing)
-Your configuration files are now into [~/git/misc/PostgreSQL/pgenv/config]
+Migrated 3 configuration file(s) from previous versions (0 not migrated)
+Your configuration file(s) are now into [~/git/misc/PostgreSQL/pgenv/config]
 ```
 
  

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ In order to start with a default configuration, use the `write` subcommand:
 
 ``` 
 $ pgenv config write default
-pgenv configuration file ~/.pgenv/.pgenv.default.conf written
+pgenv configuration file ~/.pgenv/config/.pgenv.default.conf written
 ```
 
 A subsequent `show` displays the defaults:
@@ -646,7 +646,7 @@ A subsequent `show` displays the defaults:
 $ pgenv config show default
 # Default configuration
 # pgenv configuration for PostgreSQL
-# File: /home/luca/git/misc/PostgreSQL/pgenv/.pgenv.default.conf
+# File: /home/luca/git/misc/PostgreSQL/pgenv/config/.pgenv.default.conf
 # ---------------------------------------------------
 # pgenv configuration created on mer 12 set 2018, 08.35.52, CEST
 
@@ -692,7 +692,7 @@ cannot be `init`ed more than once.
 
 ``` 
 $ pgenv config write 10.5
-pgenv configuration file [~/.pgenv/.pgenv.10.5.conf] written
+pgenv configuration file [~/.pgenv/config/.pgenv.10.5.conf] written
 ```
 
 
@@ -712,7 +712,7 @@ Use the `delete` subcommand to delete a configuration:
 
 ``` 
 $ pgenv config delete 10.5
-Configuration file ~/.pgenv/.pgenv.10.5.conf (and backup) deleted
+Configuration file ~/.pgenv/config/.pgenv.10.5.conf (and backup) deleted
 ```
    
 
@@ -724,7 +724,7 @@ However, if it is explicitly specified `default` as the version to delete
 ``` 
 $ pgenv config delete
 Cannot delete default configuration while version configurations exist
-To remove it anyway, delete ~/.pgenv/.pgenv.default.conf.
+To remove it anyway, delete ~/.pgenv/config/.pgenv.default.conf.
 ```
 The `delete` subcommand deletes both the configuration file and its backup copy.
 The `pgenv remove` command also deletes any configuration for the removed
@@ -737,6 +737,11 @@ configuration file, please issue a rename like the following
 ``` sh 
 cp .pgenv.conf .pgenv.default.conf
 ```
+
+Please note also that, since version `1.2.1` [811ba05], all the configuration files
+have been moved into the `config` subdirectory, so to keep them in a single place.
+In order to "migrate" your existing configuration, you have to manually
+copy all the `.pgenv.*.conf` files into the `config` subdirectory.
 
 ### pgenv log
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1449,6 +1449,38 @@ EOF
         configuration_file=$( pgenv_configuration_file_name $v )
 
         case $action in
+            migrate)
+                if [ -z "$PGENV_CONFIG_ROOT" ]; then
+                    PGENV_CONFIG_ROOT="$PGENV_ROOT/config"
+                    echo "No configuration directory set, using [$PGENV_CONFIG_ROOT]"
+                fi
+
+                if [ ! -d "$PGENV_CONFIG_ROOT" ]; then
+                    mkdir "$PGENV_CONFIG_ROOT"
+                fi
+
+                counter=0
+                missing=0
+                for old_config_file in "$PGENV_ROOT"/.pgenv.*.conf; do
+                    if [ -f "$old_config_file" ]; then
+                        new_config_file=$( basename "$old_config_file" | sed 's/\.pgenv\.//' )
+                        new_config_file="$PGENV_CONFIG_ROOT/${new_config_file}"
+                        pgenv_debug "Migrating [$old_config_file] to [$new_config_file]"
+                        mv "$old_config_file" "$new_config_file"
+                        if [ $? -eq 0 ]; then
+                            counter=$(( counter + 1 ))
+                        else
+                            missing=$(( missing + 1 ))
+                        fi
+                    fi
+                done
+
+                if [ $counter -gt 0 ]; then
+                    echo "Migrated $counter configuration files from previous versions ($missing missing)"
+                    echo "Your configuration files are now into [$PGENV_CONFIG_ROOT]"
+                fi
+                ;;
+
             show)
                 pgenv_configuration_dump_or_exit "$v" "$title" ;;
             init)

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -439,10 +439,10 @@ pgenv_current_postgresql_version(){
 # file is provided.
 pgenv_configuration_file_name(){
     local v=$1
-    local PGENV_DEFAULT_CONFIG_FILE="${PGENV_CONFIG_ROOT}/.pgenv.default.conf"
+    local PGENV_DEFAULT_CONFIG_FILE="${PGENV_CONFIG_ROOT}/default.conf"
 
     if [ ! -z "$v" ]; then
-        echo "${PGENV_CONFIG_ROOT}/.pgenv.$v.conf"
+        echo "${PGENV_CONFIG_ROOT}/$v.conf"
     else
         echo "${PGENV_DEFAULT_CONFIG_FILE}"
     fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1208,7 +1208,7 @@ WARNING: no configuration file found for version $v
 HINT: if you wish to customize the build process please
 stop the execution within $seconds seconds (CTRL-c) and run
 
-       pgenv config write $v && pgenv config edit $v
+       pgenv config init $v && pgenv config edit $v
 
 adjust 'configure' and 'make' options and flags and run again
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1459,25 +1459,31 @@ EOF
                     mkdir "$PGENV_CONFIG_ROOT"
                 fi
 
-                counter=0
-                missing=0
+
+                files_migrated=0
+                files_missing=0
+                files_to_migrate=0
                 for old_config_file in "$PGENV_ROOT"/.pgenv.*.conf; do
                     if [ -f "$old_config_file" ]; then
+                        files_to_migrate=$(( files_to_migrate + 1 ))
                         new_config_file=$( basename "$old_config_file" | sed 's/\.pgenv\.//' )
                         new_config_file="$PGENV_CONFIG_ROOT/${new_config_file}"
                         pgenv_debug "Migrating [$old_config_file] to [$new_config_file]"
                         mv "$old_config_file" "$new_config_file"
                         if [ $? -eq 0 ]; then
-                            counter=$(( counter + 1 ))
+                            files_migrated=$(( files_migrated + 1 ))
                         else
-                            missing=$(( missing + 1 ))
+                            files_missing=$(( files_missing + 1 ))
                         fi
                     fi
                 done
 
-                if [ $counter -gt 0 ]; then
-                    echo "Migrated $counter configuration files from previous versions ($missing missing)"
-                    echo "Your configuration files are now into [$PGENV_CONFIG_ROOT]"
+                if [ $files_to_migrate -eq 0 ]; then
+                    echo "No configuration file to migrate!"
+                else if [ $files_migrated -gt 0 ]; then
+                         echo "Migrated $files_migrated configuration file(s) from previous versions ($files_missing not migrated)"
+                         echo "Your configuration file(s) are now into [$PGENV_CONFIG_ROOT]"
+                     fi
                 fi
                 ;;
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -2,7 +2,7 @@
 #
 # VERSION
 #
-PGENV_VERSION="1.2.0"
+PGENV_VERSION="1.2.1"
 
 # https://stackoverflow.com/a/19622569/79202
 trap 'exit' ERR
@@ -18,6 +18,9 @@ fi
 cd $PGENV_ROOT
 # Always use an absolute path or configure could complain.
 PGENV_ROOT=$(pwd)
+
+# configuration file location
+PGENV_CONFIG_ROOT=${PGENV_ROOT}/config
 
 PGSQL=$PGENV_ROOT/pgsql
 PG_DATA=$PGSQL/data
@@ -436,10 +439,10 @@ pgenv_current_postgresql_version(){
 # file is provided.
 pgenv_configuration_file_name(){
     local v=$1
-    local PGENV_DEFAULT_CONFIG_FILE="${PGENV_ROOT}/.pgenv.default.conf"
+    local PGENV_DEFAULT_CONFIG_FILE="${PGENV_CONFIG_ROOT}/.pgenv.default.conf"
 
     if [ ! -z "$v" ]; then
-        echo "${PGENV_ROOT}/.pgenv.$v.conf"
+        echo "${PGENV_CONFIG_ROOT}/.pgenv.$v.conf"
     else
         echo "${PGENV_DEFAULT_CONFIG_FILE}"
     fi
@@ -637,6 +640,11 @@ pgenv_configuration_write() {
     if [ -z "$CONF" ]; then
         echo "Cannot determine which configuration file to use!"
         exit 1
+    fi
+
+    # check the configuration directory exists
+    if [ ! -d "$PGENV_CONFIG_ROOT" ]; then
+        mkdir -p "$PGENV_CONFIG_ROOT"
     fi
 
     # make a backup copy


### PR DESCRIPTION
This is related to #50.
It moves the configuration files into the `config` subdirectory, and also changes the naming scheme for configuration files. There is no need to keep them hidden anymore, as well as the `pgenv` prefix is gone.

This makes the old configuration unusable if there is no migration (i.e., file renaming). This is explained in the documentation, however, I'm unsure if this does not require a different version number bump (e.g., `1.3.0`).