### PR TITLE
Add a switch command to pgenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ will select the most recent PostgreSQL version of the 10 series installed.
 ### pgenv switch
 
 Sets the version of PostgreSQL to be used in all shells by symlinking its
-directory to `~/$PGENV_ROOT/pgsql`. Contrary to `pgenv use` this command does
+directory to `$PGENV_ROOT/pgsql`. Contrary to `pgenv use` this command does
 _not_ manage a database for you. Meaning, it will not start, stop and
 initialize a postgres database with the given version. Instead it simply
 changes the environment to a different version of PostgreSQL. This can be
@@ -587,12 +587,12 @@ $ pgenv help
 Usage: pgenv <command> [<args>]
 
 The pgenv commands are:
-    switch     Set the current PostgreSQL version
     use        Set and start the current PostgreSQL version
-    clear      Stop and unset the current PostgreSQL version
     start      Start the current PostgreSQL server
     stop       Stop the current PostgreSQL server
     restart    Restart the current PostgreSQL server
+    switch     Set the current PostgreSQL version
+    clear      Stop and unset the current PostgreSQL version
     build      Build a specific version of PostgreSQL
     rebuild    Re-build a specific version of PostgreSQL
     remove     Remove a specific version of PostgreSQL

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Synopsis
 
     # Build PostgreSQL server
     pgenv build 10.4
+
+    # Switch PostgreSQL version
+    pgenv switch 10.4
     
     # Use PostgreSQL version
     pgenv use 10.4
@@ -233,6 +236,20 @@ pgenv use latest 10
 ```
 
 will select the most recent PostgreSQL version of the 10 series installed.    
+
+### pgenv switch
+
+Sets the version of PostgreSQL to be used in all shells by symlinking its
+directory to `~/$PGENV_ROOT/pgsql`. Contrary to `pgenv use` this command does
+_not_ manage a database for you. Meaning, it will not start, stop and
+initialize a postgres database with the given version. Instead it simply
+changes the environment to a different version of PostgreSQL. This can be
+useful if the user has other tools to automate the provisioning and lifecycle
+of a database.
+
+```
+$ pgenv switch 10.4
+```
 
 ### pgenv versions
 
@@ -570,6 +587,7 @@ $ pgenv help
 Usage: pgenv <command> [<args>]
 
 The pgenv commands are:
+    switch     Set the current PostgreSQL version
     use        Set and start the current PostgreSQL version
     clear      Stop and unset the current PostgreSQL version
     start      Start the current PostgreSQL server

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -142,6 +142,7 @@ pgenv_help() {
 Usage: pgenv <command> [<args>]
 
 The pgenv commands are:
+    switch     Set the current PostgreSQL version
     use        Set and start the current PostgreSQL version
     clear      Stop and unset the current PostgreSQL version
     start      Start the current PostgreSQL server
@@ -1034,6 +1035,26 @@ pgenv_patch_source_tree() {
 }
 
 case $1 in
+    switch)
+        v=$( pgenv_guess_postgresql_version $2 $3)
+        pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
+        pgenv_installed_version_or_exit $v
+        pgenv_configuration_load $v
+
+        # check PATH settings
+        pgenv_warning_path
+
+        # Check if current version?
+        if [ "`readlink pgsql`" = "pgsql-$v" ]; then
+            echo "Already using PostgreSQL $v"
+        else
+            # Link the new instance.
+            ln -nsf pgsql-$v pgsql
+        fi
+
+        exit
+        ;;
+
     use)
         v=$( pgenv_guess_postgresql_version $2 $3)
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -142,12 +142,12 @@ pgenv_help() {
 Usage: pgenv <command> [<args>]
 
 The pgenv commands are:
-    switch     Set the current PostgreSQL version
     use        Set and start the current PostgreSQL version
-    clear      Stop and unset the current PostgreSQL version
     start      Start the current PostgreSQL server
     stop       Stop the current PostgreSQL server
     restart    Restart the current PostgreSQL server
+    switch     Set the current PostgreSQL version
+    clear      Stop and unset the current PostgreSQL version
     build      Build a specific version of PostgreSQL
     rebuild    Re-build a specific version of PostgreSQL
     remove     Remove a specific version of PostgreSQL

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -1035,27 +1035,10 @@ pgenv_patch_source_tree() {
 }
 
 case $1 in
-    switch)
-        v=$( pgenv_guess_postgresql_version $2 $3)
-        pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
-        pgenv_installed_version_or_exit $v
-        pgenv_configuration_load $v
+    use|switch)
+        # save the 'command' to check if we should initialize and start the database or not
+        command=$1
 
-        # check PATH settings
-        pgenv_warning_path
-
-        # Check if current version?
-        if [ "`readlink pgsql`" = "pgsql-$v" ]; then
-            echo "Already using PostgreSQL $v"
-        else
-            # Link the new instance.
-            ln -nsf pgsql-$v pgsql
-        fi
-
-        exit
-        ;;
-
-    use)
         v=$( pgenv_guess_postgresql_version $2 $3)
         pgenv_input_version_or_exit "$v" 'show-installed-versions' 'build'
         pgenv_installed_version_or_exit $v
@@ -1078,11 +1061,15 @@ case $1 in
             ln -nsf pgsql-$v pgsql
         fi
 
-        # Init if needed.
-        pgenv_initdb
+        # only start the database if the user specified the need to use the database
+        if [ "$command" == 'use' ]; then
+            # Init if needed.
+            pgenv_initdb
 
-        # start the instance
-        pgenv_start_instance
+            # start the instance
+            pgenv_start_instance
+        fi
+
         exit
         ;;
 


### PR DESCRIPTION
The `switch` command acts mostly like `use`, however, it does not manage any database for you, it simply changes the version linked and thus in the path of the user.

When developing the citus extension for postgres we often need to manage many different postgres databases running on the same machine (different ports) at once. We have our own tooling to create these databases from the postgres version installed on the path.

By omitting the starting, stopping and initializing of the database we can still use `pgenv` to manage different versions of postgres on the same machine.

Last years we used a fork of `pgenv` with some more functionality hacked in. Over time most of that functionality have been better implemented by the `pgenv` community. The last missing piece for now is a lightweight way of switching which postgres version is on the path without managing a database.