### PR TITLE
Remove `declare` from array definitions.

### DIFF
--- a/bin/pgenv
+++ b/bin/pgenv
@@ -2,7 +2,7 @@
 #
 # VERSION
 #
-PGENV_VERSION="1.3.1"
+PGENV_VERSION="1.3.2"
 
 # https://stackoverflow.com/a/19622569/79202
 trap 'exit' ERR
@@ -620,9 +620,10 @@ pgenv_configuration_write_variable(){
 
 
     if [[ "$name" =~ _OPTIONS$ ]]; then
-        # declare has no way to output a global variable
-        # that is then needed when reloading configuration !
-        declare  -p "${name}"  >> "$file"
+        # using `declare` will make the variable `local`
+        # once it is read from the pgenv_configuration_read function
+        # so don't use it and export as a global variable
+        declare -p "${name}" | sed 's/^declare -a\ //' >> "$file"
         echo "export ${name}"  >> "$file"
     else
         # if no value supplied, put a comment


### PR DESCRIPTION
`declare -a` is used for arrays when `declare -p` dumps the configuration. However when `pgenv_configuration_read` gets back the configuration, variables becomes locally scoped (see `bash -c "help declare"). One solution could be to use `declare -g` to make variables globals, but this does not works on OSX.
Removing `declare -a` from arrays seems to make the variable global even if no `EXPORT` is issued. As a possible compatibility statement, the `EXPORT` after each variable is left in place.

Close #56