### PR TITLE
Enrivonment variable to force the configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,8 +635,8 @@ The `config` command accepts the following subcommands:
            (Using `$EDITOR`, e.g: `export EDITOR=/usr/bin/emacs`)
 -    `delete` removes the specified configuration
 -    `migrate` is a command used to change the configuration format between versions of `pgenv`
--    `use` accepts a versione number and prints on standard output the environment variable that,
-           once exported, will force `pgenv` to use that configuration file
+-    `path` accepts a version number and prints on standard output the path to such version
+            configuration path
  
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a
@@ -773,19 +773,29 @@ Your configuration file(s) are now into [~/git/misc/PostgreSQL/pgenv/config]
 ```
 
 
-The `use` command accepts a specific version that will be used to compute the
-configuration file name related to such version, and the environment variable
-`PGENV_CONFIGURATION_FILE` will be printed out.
-It is required that variable to be exported or used within the shell session
-for subsequent `pgenv` invocations to use such configuration file. For example:
+The `path` command accepts a specific version that will be used to compute the
+configuration file name related to such version, printing out the resulting
+path to the configuration file.
+This allows the user to set the `PGENV_CONFIGURATION_FILE` environment variable
+to a specific path to a custom configuration file, so that other subsequent
+invocations of `pgenv` will refer to such path.
+As an example, this is a way to exploit the default configuration file
+for different versions of PostgreSQL.
+In order to export the variable to a specific custom file location
+you can do, in your terminal, something like the following:
 
 ```
-export $( pgenv config use 15.4 )
+export PGENV_CONFIGURATION_FILE=$( pgenv config path 15.4 )
 ```
 
 The above will set the environment variable `PGENV_CONFIGURATION_FILE` to the configuration
 file for the PostgreSQL version `15.4`.
+If you want to use the default configuration file, substitute the version number with the
+special `default` keyowrd, for example:
 
+```
+export PGENV_CONFIGURATION_FILE=pgenv config path default
+```
  
 ### pgenv log
 

--- a/README.md
+++ b/README.md
@@ -635,6 +635,8 @@ The `config` command accepts the following subcommands:
            (Using `$EDITOR`, e.g: `export EDITOR=/usr/bin/emacs`)
 -    `delete` removes the specified configuration
 -    `migrate` is a command used to change the configuration format between versions of `pgenv`
+-    `use` accepts a versione number and prints on standard output the environment variable that,
+           once exported, will force `pgenv` to use that configuration file
  
 
 Each sub-command accepts a PostgreSQL version number (e.g., `10.5`) or a
@@ -769,6 +771,20 @@ pgenv config migrate
 Migrated 3 configuration file(s) from previous versions (0 not migrated)
 Your configuration file(s) are now into [~/git/misc/PostgreSQL/pgenv/config]
 ```
+
+
+The `use` command accepts a specific version that will be used to compute the
+configuration file name related to such version, and the environment variable
+`PGENV_CONFIGURATION_FILE` will be printed out.
+It is required that variable to be exported or used within the shell session
+for subsequent `pgenv` invocations to use such configuration file. For example:
+
+```
+export $( pgenv config use 15.4 )
+```
+
+The above will set the environment variable `PGENV_CONFIGURATION_FILE` to the configuration
+file for the PostgreSQL version `15.4`.
 
  
 ### pgenv log

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -674,14 +674,25 @@ pgenv_configuration_write_variable(){
 # Writes the whole current configuration to the current version file
 # or the version file specified. It does a backup copy in the case
 # the file already exists.
+#
+# If the environment variable PGENV_CONFIGURATION_FILE is set
+# no configuration file (over)writing will happen: it is supposed
+# the user has declared the variable and thus it is not required to
+# update the configuration.
 pgenv_configuration_write() {
     local v=$1
     CONF=$( pgenv_configuration_file_name $v )
 
     # sanity check
     if [ -z "$CONF" ]; then
-        echo "Cannot determine which configuration file to use!"
+        echo "Cannot determine which configuration file to use!" > 2
         exit 1
+    fi
+
+    # avoid overwriting configuration if the environment variable is set
+    if [ ! -z "${PGENV_CONFIGURATION_FILE}" ]; then
+	pgenv_debug "Cannot write configuration file while PGENV-CONFIGURATION_FILE set!"
+	exit 1
     fi
 
     # check the configuration directory exists

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -610,23 +610,20 @@ EOF
 
 
 # Utility function to print on stdout
-# the variable to use in order to force a configuration
-# file decided by the user.
+# the path to which the program will look for a
+# configuration file.
 #
-# For example, in a shell run
+# This can be useful to exdport the environment variable
+# to point to a custom path, like this:
 #
-#    % export $(pgenv config use 16neta2)
+#    % export PGENV_CONFIGURATION_FILE=$( pgenv config path 16neta2 )
 #
 # that will result in setting the PGENV_CONFIGURATION_FILE
 # so that following usage of `pgenv` will use such a configuration
 # file.
-pgenv_configuration_use(){
+pgenv_configuration_show_path(){
     local v=$1
-    local c=$( pgenv_configuration_file_name "$v" "SKIP-ENV" )
-
-    pgenv_debug "Configuration use for [$v] -> [$c]"
-    echo "PGENV_CONFIGURATION_FILE=$c"
-
+    echo $( pgenv_configuration_file_name "$v" "SKIP-ENV" )
 }
 
 # Utility function to write a single variable in the configuration file.
@@ -1577,8 +1574,8 @@ EOF
                 ;;
             delete)
                 pgenv_configuration_delete "$v" "$nuke";;
-	    use)
-		pgenv_configuration_use "$v";;
+	    path)
+		pgenv_configuration_show_path "$v";;
             *)
                 if [ -z "$action" ]; then
                     cat <<EOF >&2

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -438,9 +438,27 @@ pgenv_current_postgresql_version(){
 #
 # If no version is specified, the default configuration
 # file is provided.
+#
+# If the user has defined an environment variable named
+#       PGENV_CONFIGURATION_FILE
+# the function returns such name. This allows the user
+# to use always a well established configuration file.
+# It is possible to avoid the usage of the PGENV_CONFIGURATION_FILE
+# environment variable if the second argument is something not null.
 pgenv_configuration_file_name(){
     local v=$1
+    local skip_env=$2
     local PGENV_DEFAULT_CONFIG_FILE="${PGENV_CONFIG_ROOT}/default.conf"
+
+
+    # if the user has defined an environment variable PGENV_CONFIGURATION_FILE
+    # I need to use that instead of trying to understand which file to use
+    if [ ! -z "$PGENV_CONFIGURATION_FILE" -a -z "$skip_env" ]; then
+	pgenv_debug "Configuration file overwritten by environment variable PGENV_CONFIGURATION_FILE = $PGENV_CONFIGURATION_FILE"
+	echo "${PGENV_CONFIGURATION_FILE}"
+	return
+    fi
+
 
     if [ ! -z "$v" ]; then
         echo "${PGENV_CONFIG_ROOT}/$v.conf"
@@ -588,6 +606,27 @@ EOF
     rm -f "$PGENV_CONFIG_FILE"            # remove config file
     rm -f ${PGENV_CONFIG_FILE}*.backup    # remove also backup file
     echo "Configuration file $PGENV_CONFIG_FILE (and backup) deleted"
+}
+
+
+# Utility function to print on stdout
+# the variable to use in order to force a configuration
+# file decided by the user.
+#
+# For example, in a shell run
+#
+#    % export $(pgenv config use 16neta2)
+#
+# that will result in setting the PGENV_CONFIGURATION_FILE
+# so that following usage of `pgenv` will use such a configuration
+# file.
+pgenv_configuration_use(){
+    local v=$1
+    local c=$( pgenv_configuration_file_name "$v" "SKIP-ENV" )
+
+    pgenv_debug "Configuration use for [$v] -> [$c]"
+    echo "PGENV_CONFIGURATION_FILE=$c"
+
 }
 
 # Utility function to write a single variable in the configuration file.
@@ -1538,6 +1577,8 @@ EOF
                 ;;
             delete)
                 pgenv_configuration_delete "$v" "$nuke";;
+	    use)
+		pgenv_configuration_use "$v";;
             *)
                 if [ -z "$action" ]; then
                     cat <<EOF >&2
@@ -1548,7 +1589,7 @@ You need to specify one of the following \`config\` actions to perform:
     write
     edit
     delete
-
+    use
 
 For instance:
 


### PR DESCRIPTION
The command now will honor the environment variable `PGENV_CONFIGURATION_FILE` so that, if set, will determine the path to the configuration file to be used during all the operations. This allows to decied which configuration file to use before the `pgenv` starts working, so for example:

    % export PGENV_CONFIGURATION_FILE=~/git/pgenv/config/default.conf
    % pgenv build 16beta2

will use the default configuration file instead of a version specific one.

Added also a `pgenv config use <version>` command that prints the environment variable to export or set in the shell session (but does not set itself), so that it is possible to do

   % export $( pgenv config use default )

to obtain the environment changed, and hence ease the "computation" of which file name to use for a specific version.

Close #60