### PR TITLE
Environment variable to prevent  automatic configuration file creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,15 @@ interpreter, pass it on the command line at the time of build:
 PERL=/usr/local/my-fancy-perl pgenv build 10.5
 ```
 
+At the end of a `build` (or a `rebuild`) phase, `pgenv` creates a configuration
+file for the specific PostgreSQL version. If the file already exists, due to
+a prior `build` or `rebuild` action, the file will be automatically overwritten.
+In order to avoid the overwriting of the configuration file, it is possible to
+set the environment variable `PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY` to
+a false value (either `0` or `NO`). If the variable is not set at all,
+or it is set to a true value (e.g., `1`, `YES`, etc.)
+the configuration file will be overwritten.
+
 #### Patching
 
 `pgenv` can patch the source tree before the build process starts. In
@@ -796,7 +805,9 @@ special `default` keyowrd, for example:
 ```
 export PGENV_CONFIGURATION_FILE=pgenv config path default
 ```
- 
+
+
+
 ### pgenv log
 
 The `log` command provides a dump of the cluster log, if it exists, so that you

--- a/README.md
+++ b/README.md
@@ -366,11 +366,12 @@ PERL=/usr/local/my-fancy-perl pgenv build 10.5
 At the end of a `build` (or a `rebuild`) phase, `pgenv` creates a configuration
 file for the specific PostgreSQL version. If the file already exists, due to
 a prior `build` or `rebuild` action, the file will be automatically overwritten.
-In order to avoid the overwriting of the configuration file, it is possible to
-set the environment variable `PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY` to
-a false value (either `0` or `NO`). If the variable is not set at all,
+In order to avoid the creation or overwriting of the configuration file,
+it is possible to set the environment variable
+`PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY` to a false value
+(either `0` or `NO`). If the variable is not set at all,
 or it is set to a true value (e.g., `1`, `YES`, etc.)
-the configuration file will be overwritten.
+the configuration file will be created or  overwritten (if it already exists).
 
 #### Patching
 

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -2,7 +2,7 @@
 #
 # VERSION
 #
-PGENV_VERSION="1.3.2"
+PGENV_VERSION="1.3.3"
 
 # https://stackoverflow.com/a/19622569/79202
 trap 'exit' ERR
@@ -454,7 +454,7 @@ pgenv_configuration_file_name(){
     # if the user has defined an environment variable PGENV_CONFIGURATION_FILE
     # I need to use that instead of trying to understand which file to use
     if [ ! -z "$PGENV_CONFIGURATION_FILE" -a -z "$skip_env" ]; then
-	pgenv_debug "Configuration file overwritten by environment variable PGENV_CONFIGURATION_FILE = $PGENV_CONFIGURATION_FILE"
+	pgenv_debug "Configuration file forced by environment variable PGENV_CONFIGURATION_FILE = $PGENV_CONFIGURATION_FILE"
 	echo "${PGENV_CONFIGURATION_FILE}"
 	return
     fi
@@ -675,10 +675,12 @@ pgenv_configuration_write_variable(){
 # or the version file specified. It does a backup copy in the case
 # the file already exists.
 #
-# If the environment variable PGENV_CONFIGURATION_FILE is set
-# no configuration file (over)writing will happen: it is supposed
-# the user has declared the variable and thus it is not required to
-# update the configuration.
+# If the environment variable PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY
+# is set to a non-empty, non-zero value, the configuration file
+# will be overwritten. In the case the variable is not set at all
+# the application will apply the backward compatible behavior, so
+# not setting the PGENV_CONFIGURATION_FILE_AUTOMATICALLY is like
+# setting it to "YES".
 pgenv_configuration_write() {
     local v=$1
     CONF=$( pgenv_configuration_file_name $v )
@@ -689,11 +691,21 @@ pgenv_configuration_write() {
         exit 1
     fi
 
-    # avoid overwriting configuration if the environment variable is set
-    if [ ! -z "${PGENV_CONFIGURATION_FILE}" ]; then
-	pgenv_debug "Cannot write configuration file while PGENV_CONFIGURATION_FILE set!"
-	return
+
+    # check if we need to write the configuration file automatically:
+    # if the variable is not set, assume the user wants the backward
+    # compatible behavior: write the configuration file automatically
+    if [ -z "$PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY" ]; then
+	PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY="YES"
     fi
+
+    # in the case the variable is set to a non-yes value, avoid overwriting
+    case "$PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY" in
+	0|[nN][oO])
+	pgenv_debug "Not writing config file automatically: set \`PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY\` to a true value to enable the automatic file writing"
+	return
+	;;
+    esac
 
     # check the configuration directory exists
     if [ ! -d "$PGENV_CONFIG_ROOT" ]; then


### PR DESCRIPTION
This commit introduces the
PGENV_WRITE_CONFIGURATION_FILE_AUTOMATICALLY
environment variable that, if set to true, allows `pgenv` to write a configuration file automatically at the end of a build/rebuild, while a false or zero or no value means that the program is not allowed to create a new configuration file.

This breaks compatibility, since the behavior before this version was to always write a new configuration file, while since this version the default behavior is to not write the configuration file automatically.

Close #62