### PR TITLE
Ignore config as diretory or symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /pgsql*
 /src/
 /.pgenv.*
-/config/
+/config
+.DS_Store


### PR DESCRIPTION
Also ignore `.DS_Store` files that macOS sometimes creates.