### PR TITLE
#76 make dependency check messages more descriptive

### DIFF
--- a/bin/pgenv
+++ b/bin/pgenv
@@ -199,7 +199,7 @@ pgenv_check_dependencies(){
         local nl=$'\n'
         local tab=$'\t'
         if [ -z "$command" ]; then
-                missing+="[ERROR] $command_name${tab}required but NOT found!$nl"
+                missing+="[ERROR] $command_name:${tab}required but NOT found!$nl"
         else
             present+="[FOUND] $command_name:$tab$command$nl"
         fi

--- a/bin/pgenv
+++ b/bin/pgenv
@@ -199,9 +199,9 @@ pgenv_check_dependencies(){
         local nl=$'\n'
         local tab=$'\t'
         if [ -z "$command" ]; then
-                missing+="[KO] $command_name:${tab}NOT found!$nl"
+                missing+="[ERROR] $command_name${tab}required but NOT found!$nl"
         else
-            present+="[OK] $command_name:$tab$command$nl"
+            present+="[FOUND] $command_name:$tab$command$nl"
         fi
     }
 


### PR DESCRIPTION
Replaced OK and KO indicators with FOUND and ERROR respectively.
Made description more descriptive by adding "required but" to the string when utility is missing - suggested by @fluca1978 .